### PR TITLE
read the duffy key from the workspace on the slave instead of checking it in directly

### DIFF
--- a/provisions/ci/setup_env.sh
+++ b/provisions/ci/setup_env.sh
@@ -3,7 +3,7 @@ if [ -f env.properties ]; then
 fi
 touch env.properties
 echo "URL_BASE=http://admin.ci.centos.org:8080" >> env.properties
-echo "API=914f27e6-84a0-11e5-b2e3-525400ea212d" >> env.properties
+echo "API=$(cat ~/duffy.key)" >> env.properties
 
 bash utils/gencert.sh registry.centos.org || true
 echo -e  'y\n'| ssh-keygen -t rsa -N "" -f jenkins.key


### PR DESCRIPTION
The CentOS CI Service provides the duffy key in ~/duffy.key, we should read that in directly instead of checking it in to version control.

This PR will need a JJB run to update the jobs.