### PR TITLE
Fixes for test worker and cccp-index job

### DIFF
--- a/beanstalk_worker/worker_start_test.py
+++ b/beanstalk_worker/worker_start_test.py
@@ -7,7 +7,7 @@ import logging
 import sys
 import time
 
-CENTOS7 = "dev-32-94.lon1.centos.org"
+CENTOS7 = "atomic-scan.vm.centos.org"
 DOCKER_PORT = "4243"
 
 logger = logging.getLogger("container-pipeline")

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -64,8 +64,8 @@ def main(yamlfile):
                 )   
                 new_proj= [{'project':{}}]
                 
-                appid = appid.replace('_','-').replace('/','-')
-                jobid = jobid.replace('_','-').replace('/','-')
+                appid = appid.replace('_','-').replace('/','-').replace('.','-')
+                jobid = jobid.replace('_','-').replace('/','-').replace('.','-')
 
                 # overwrite any attributes we care about see: projectify
                 with open(generated_filename, 'w') as outfile:

--- a/provisions/roles/jenkins/master/templates/index.yml.j2
+++ b/provisions/roles/jenkins/master/templates/index.yml.j2
@@ -11,7 +11,7 @@
         - pollscm: "H/10 * * * *" 
     builders:
         - shell: |
-            git clone https://github.com/bamachrn/cccp-service.git
-            cd cccp-service/jenkinsbuilder
+            git clone https://github.com/CentOS/container-pipeline-service.git
+            cd container-pipeline-service/jenkinsbuilder
             python cccp_index_reader.py ../../index.yml
 


### PR DESCRIPTION
* Fixes for https://github.com/CentOS/container-pipeline-service/issues/25
and https://github.com/CentOS/container-pipeline-service/issues/24
* Replacing '.' character to match openshift project naming convention 