### PR TITLE
Adds .vagrant directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *.swo
+.vagrant


### PR DESCRIPTION
Creating a vagrant vm for dev purpose shows `.vagrant` directory in every `git status` command.