### PR TITLE
Add log to worker for falied messages

### DIFF
--- a/atomic_scanners/pipeline-scanner/Dockerfile
+++ b/atomic_scanners/pipeline-scanner/Dockerfile
@@ -2,8 +2,7 @@ FROM centos:centos7
 
 LABEL INSTALL='docker run -it --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 
-# Install python-docker-py to spin up container using scan script
-RUN yum -y update && yum -y install python-docker-py && yum clean all
+RUN yum -y update && yum clean all
 
 ADD pipeline-scanner /
 ADD scanner.py /

--- a/beanstalk_worker/cccp-scan-worker.service
+++ b/beanstalk_worker/cccp-scan-worker.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=cccp-scan-worker.service
+
+[Service]
+ExecStart=/opt/cccp-service/beanstalk_worker/worker_start_scan.py

--- a/beanstalk_worker/cccp-test-worker.service
+++ b/beanstalk_worker/cccp-test-worker.service
@@ -1,5 +1,0 @@
-[Unit]
-Description=cccp-test-worker.service
-
-[Service]
-ExecStart=/opt/cccp-service/beanstalk_worker/worker_start_test.py

--- a/beanstalk_worker/worker_dispatcher.py
+++ b/beanstalk_worker/worker_dispatcher.py
@@ -14,8 +14,8 @@ bs.watch("master_tube")
 while True:
   print "listening to master_tube"
   job = bs.reserve()
-  job_details = json.loads(job.body) 
-  
+  job_details = json.loads(job.body)
+
   print "==> Retrieving job action"
   action = job_details['action']
 
@@ -23,8 +23,8 @@ while True:
     bs.use("start_build")
     bs.put(json.dumps(job_details))
     print "==> Job moved to build tube"
-  elif action == "start_test" :
-    bs.use("start_test")
+  elif action == "start_scan" :
+    bs.use("start_scan")
     bs.put(json.dumps(job_details))
     print "==>job moved to test tube"
   elif action == "start_delivery" :
@@ -35,6 +35,6 @@ while True:
     bs.use("notify_user")
     bs.put(json.dumps(job_details))
     print "==> Job moved to notify tube"
-  
+
   print "==> Deleting job"
   job.delete()

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -43,8 +43,8 @@ def run_command(command):
 def notify_build_failure(namespace, notify_email, logs):
     msg_details = {}
     msg_details['action'] = 'notify_user'
-    msg_details['subject'] = "Container-build failed"+namespace
-    msg_details['msg'] = "Container build for " + namespace + "failed due to error in build or test steps. Pleae check attached logs"
+    msg_details['subject'] = "Container-build failed "+namespace
+    msg_details['msg'] = "Container build for " + namespace + " is failed due to error in build or test steps. Pleae check attached logs"
     msg_details['logs'] = logs
     msg_details['to_mail'] = notify_email
     bs.use('master_tube')

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -6,7 +6,6 @@ from subprocess import Popen
 from subprocess import PIPE
 import re
 import time
-from DependencyChecker import DependencyChecker
 import logging
 import sys
 

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -56,7 +56,7 @@ def start_build(job_details):
         debug_log(" Retrieving namespace")
         name = job_details['name']
         tag = job_details['tag']
-        depends_on = job_details['depends_on']
+        #depends_on = job_details['depends_on']
         notify_email = job_details['notify_email']
 
         debug_log("Login to openshift server")
@@ -95,7 +95,7 @@ def start_build(job_details):
 
         is_complete=run_command(status_command)[0].find('Complete')
 
-        //checking logs for the build phase
+        #checking logs for the build phase
         log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
         logs = run_command(log_command)
 

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -31,7 +31,7 @@ DEBUG=1
 
 def debug_log(msg):
     if DEBUG==1:
-        logger.log(level=logging.INFO,msg=msg)
+        logger.log(level=logging.DEBUG, msg=msg)
 
 def run_command(command):
     p = Popen(command,bufsize=0,shell=True,stdout=PIPE,stderr=PIPE,stdin=PIPE)
@@ -42,7 +42,7 @@ def run_command(command):
 def notify_build_failure(namespace, notify_email, logs):
     msg_details = {}
     msg_details['action'] = 'notify_user'
-    msg_details['subject'] = "Container-build failed "+namespace
+    msg_details['subject'] = "FAILED: Container-build failed "+namespace
     msg_details['msg'] = "Container build for " + namespace + " is failed due to error in build or test steps. Pleae check attached logs"
     msg_details['logs'] = logs
     msg_details['to_mail'] = notify_email

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -31,88 +31,94 @@ config_path = "/".join(sys.argv[0].split("/")[:-1])
 DEBUG=1
 
 def debug_log(msg):
-  if DEBUG==1:
-    logger.log(level=logging.INFO,msg=msg)
+    if DEBUG==1:
+        logger.log(level=logging.INFO,msg=msg)
 
 def run_command(command):
-  p = Popen(command,bufsize=0,shell=True,stdout=PIPE,stderr=PIPE,stdin=PIPE)
-  p.wait()
-  out = p.communicate()
-  return out
+    p = Popen(command,bufsize=0,shell=True,stdout=PIPE,stderr=PIPE,stdin=PIPE)
+    p.wait()
+    out = p.communicate()
+    return out
+
+def notify_build_failure(namespace, notify_email, logs):
+    msg_details = {}
+    msg_details['action'] = 'notify_user'
+    msg_details['subject'] = "Container-build failed"+namespace
+    msg_details['msg'] = "Container build failed due to error in build or test steps. Pleae check attached logs"
+    msg_details['logs'] = logs
+    msg_details['to_mail'] = notify_email
+    bs.use('master_tube')
+    bs.put(json.dumps(msg_details))
 
 
 def start_build(job_details):
-  try:
-    debug_log(" Retrieving namespace")
-    name = job_details['name']
-    tag = job_details['tag']
-    depends_on = job_details['depends_on']
-  
-    #print "==> check dependencies are available or not"
-    #dependency_present = False
-    #if depends_on == None:
-    #  dependency_present = True
+    try:
+        debug_log(" Retrieving namespace")
+        name = job_details['name']
+        tag = job_details['tag']
+        depends_on = job_details['depends_on']
+        notify_email = job_details['notify_email']
 
-    #dc = DependencyChecker()
-    #while dependency_present != True
-    #  dependency_present = dc.checkdependencies(depends_on)
-    #  time.sleep(30)
+        debug_log("Login to openshift server")
+        command_login = "oc login https://openshift:8443 -u test-admin -p test --config="+config_path+"/node.kubeconfig --certificate-authority="+config_path+"/ca.crt"
+        out = run_command(command_login)
+        debug_log(out)
 
-    debug_log("Login to openshift server")
-    command_login = "oc login https://openshift:8443 -u test-admin -p test --config="+config_path+"/node.kubeconfig --certificate-authority="+config_path+"/ca.crt"
-    out = run_command(command_login)
-    debug_log(out)
+        debug_log(" change project to the desired one")
+        command_change_project = "oc project "+name+"-"+tag+" --config="+config_path+"/node.kubeconfig"
+        out = run_command(command_change_project)
+        debug_log(out)
 
-    debug_log(" change project to the desired one")
-    command_change_project = "oc project "+name+"-"+tag+" --config="+config_path+"/node.kubeconfig"
-    out = run_command(command_change_project)
-    debug_log(out)
-  
-    debug_log("start the build")
-    command_start_build = "oc --namespace "+name+"-"+tag+" start-build build --config="+config_path+"/node.kubeconfig"
-    out = run_command(command_start_build)
-    debug_log(out)
+        debug_log("start the build")
+        command_start_build = "oc --namespace "+name+"-"+tag+" start-build build --config="+config_path+"/node.kubeconfig"
+        out = run_command(command_start_build)
+        debug_log(out)
 
-    build_details = out[0].rstrip()
-    debug_log(build_details)
+        build_details = out[0].rstrip()
+        debug_log(build_details)
 
-    if build_details=="":
-      logger.log(level=logging.CRITICAL, msg="build could not be started as openshift is not reachable")
-      return 1
+        if build_details=="":
+            logger.log(level=logging.CRITICAL, msg="build could not be started as openshift is not reachable")
+            return 1
 
-    debug_log("build started is "+build_details)
+        debug_log("build started is "+build_details)
 
-    status_command = "oc get --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig|grep -v STATUS"
-    is_running = 1
+        status_command = "oc get --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig|grep -v STATUS"
+        is_running = 1
 
-    debug_log("Checking the build status")
-    while is_running >= 0:
-      status= run_command(status_command)[0].rstrip()
-      is_running = re.search("New|Pending|Running",status)
-      debug_log("current status: "+status)
-      time.sleep(30)
+        debug_log("Checking the build status")
+        while is_running >= 0:
+            status= run_command(status_command)[0].rstrip()
+            is_running = re.search("New|Pending|Running",status)
+            debug_log("current status: "+status)
+            time.sleep(30)
 
-    is_complete=run_command(status_command)[0].find('Complete')
+        is_complete=run_command(status_command)[0].find('Complete')
 
-    if is_complete < 0:
-      bs.put(json.dumps(job_details))
-      debug_log("Build is not successful putting it to failed build tube")
+        //checking logs for the build phase
+        log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
+        logs = run_command(log_command)
 
-    return 0
-  except Exception as e:
-    logger.log(level=logging.CRITICAL, msg=e.message)
-    return 1
+        if is_complete < 0:
+            bs.put(json.dumps(job_details))
+            notify_build_failure(name+"-"+tag, notify_email, logs);
+            debug_log("Build is not successful putting it to failed build tube")
+
+        return 0
+    except Exception as e:
+        logger.log(level=logging.CRITICAL, msg=e.message)
+        return 1
 
 while True:
-  try:
-    debug_log("listening to start_build tube")
-    job = bs.reserve()
-    job_details = json.loads(job.body) 
-    result = start_build(job_details)
-    if result == 0:
-      debug_log("Build is successful deleting the job")
-      job.delete()
-    else:
-      debug_log("Job was not succesfull and returned to tube")
-  except Exception as e:
-    logger.log(level=logging.CRITICAL, msg=e.message)
+    try:
+        debug_log("listening to start_build tube")
+        job = bs.reserve()
+        job_details = json.loads(job.body)
+        result = start_build(job_details)
+        if result == 0:
+            debug_log("Build is successful deleting the job")
+            job.delete()
+        else:
+            debug_log("Job was not succesfull and returned to tube")
+    except Exception as e:
+        logger.log(level=logging.CRITICAL, msg=e.message)

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -44,7 +44,7 @@ def notify_build_failure(namespace, notify_email, logs):
     msg_details = {}
     msg_details['action'] = 'notify_user'
     msg_details['subject'] = "Container-build failed"+namespace
-    msg_details['msg'] = "Container build failed due to error in build or test steps. Pleae check attached logs"
+    msg_details['msg'] = "Container build for " + namespace + "failed due to error in build or test steps. Pleae check attached logs"
     msg_details['logs'] = logs
     msg_details['to_mail'] = notify_email
     bs.use('master_tube')

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -98,6 +98,7 @@ def start_build(job_details):
         #checking logs for the build phase
         log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
         logs = run_command(log_command)
+        logs = logs[0]
 
         if is_complete < 0:
             bs.put(json.dumps(job_details))

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -32,11 +32,7 @@ DEBUG=1
 def notify_build_failure(name_space, notify_email, logs):
     msg_details = {}
     msg_details['action'] = 'notify_user'
-<<<<<<< 43da7e338eab07ee865b05ba42c6738ea96c5b2c
     msg_details['subject'] = "FAILED: Container-build failed"+namespace
-=======
-    msg_details['subject'] = "Container-build failed"+namespace
->>>>>>> Added failure notification to delivery bit
     msg_details['msg'] = "Container build "+ namespace +" failed due to error in build or test steps. Pleae check attached logs"
     msg_details['logs'] = logs
     msg_details['to_mail'] = notify_email
@@ -48,11 +44,7 @@ def debug_log(msg):
         logger.log(level=logging.INFO,msg=msg)
 
 def run_command(command):
-<<<<<<< 43da7e338eab07ee865b05ba42c6738ea96c5b2c
     p = Popen(command,bufsize=0,shell = True,stdout = PIPE,stderr = PIPE,stdin = PIPE)
-=======
-    p = Popen(command,bufsize=0,shelli = True,stdout = PIPE,stderr = PIPE,stdin = PIPE)
->>>>>>> Added failure notification to delivery bit
     p.wait()
     out = p.communicate()
     return out

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -95,7 +95,11 @@ def start_delivery(job_details):
 
         is_complete=run_command(status_command)[0].find('Complete')
         #checking logs for the build phase
+<<<<<<< dd68278c2b0de778c873e44ddcc7c0912a6a9863
         log_command = "oc logs --namespace "+name_space+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
+=======
+        log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
+>>>>>>> Added notify_email to delivery tube
         logs = run_command(log_command)
         logs = logs[0]
 

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -30,78 +30,82 @@ config_path = "/".join(sys.argv[0].split("/")[:-1])
 DEBUG=1
 
 def debug_log(msg):
-  if DEBUG==1:
-    logger.log(level=logging.INFO,msg=msg)
+    if DEBUG==1:
+        logger.log(level=logging.INFO,msg=msg)
 
 def run_command(command):
-  p = Popen(command,bufsize=0,shell=True,stdout=PIPE,stderr=PIPE,stdin=PIPE)
-  p.wait()
-  out = p.communicate()
-  return out
+    p = Popen(command,bufsize=0,shell=True,stdout=PIPE,stderr=PIPE,stdin=PIPE)
+    p.wait()
+    out = p.communicate()
+    return out
 
 
 def start_delivery(job_details):
-  try:
-    debug_log("Retrieving namespace")
-    name_space = job_details['name_space']
-    #tag = job_details['tag']
-    #depends_on = job_details['depends_on']
+    try:
+        debug_log("Retrieving namespace")
+        name_space = job_details['name_space']
+        #tag = job_details['tag']
+        #depends_on = job_details['depends_on']
   
-    debug_log("Login to openshift server")
-    command_login = "oc login https://openshift:8443 -u test-admin -p test --config="+config_path+"/node.kubeconfig --certificate-authority="+config_path+"/ca.crt"
-    out = run_command(command_login)
-    debug_log(out)
+        debug_log("Login to openshift server")
+        command_login = "oc login https://openshift:8443 -u test-admin -p test --config="+config_path+"/node.kubeconfig --certificate-authority="+config_path+"/ca.crt"
+        out = run_command(command_login)
+        debug_log(out)
 
-    debug_log(" change project to the desired one")
-    command_change_project = "oc project "+name_space+" --config="+config_path+"/node.kubeconfig"
-    out = run_command(command_change_project)
-    debug_log(out)
+        debug_log(" change project to the desired one")
+        command_change_project = "oc project "+name_space+" --config="+config_path+"/node.kubeconfig"
+        out = run_command(command_change_project)
+        debug_log(out)
   
-    debug_log("start the delivery")
-    command_start_build = "oc --namespace "+name_space+" start-build delivery --config="+config_path+"/node.kubeconfig"
-    out = run_command(command_start_build)
-    debug_log(out)
+        debug_log("start the delivery")
+        command_start_build = "oc --namespace "+name_space+" start-build delivery --config="+config_path+"/node.kubeconfig"
+        out = run_command(command_start_build)
+        debug_log(out)
 
-    build_details = out[0].rstrip()
-    debug_log(build_details)
+        build_details = out[0].rstrip()
+        debug_log(build_details)
 
-    if build_details=="":
-      logger.log(level=logging.CRITICAL, msg="build could not be started as openshift is not reachable")
-      return 1
+        if build_details=="":
+            logger.log(level=logging.CRITICAL, msg="build could not be started as openshift is not reachable")
+            return 1
 
-    debug_log("Delivery started is "+build_details)
+        debug_log("Delivery started is "+build_details)
 
-    status_command = "oc get --namespace "+name_space+" build/"+build_details+" --config="+config_path+"/node.kubeconfig|grep -v STATUS"
-    is_running = 1
+        status_command = "oc get --namespace "+name_space+" build/"+build_details+" --config="+config_path+"/node.kubeconfig|grep -v STATUS"
+        is_running = 1
 
-    debug_log("Checking the delivery status")
-    while is_running >= 0:
-      status= run_command(status_command)[0].rstrip()
-      is_running = re.search("New|Pending|Running",status)
-      debug_log("current status: "+status)
-      time.sleep(30)
+        debug_log("Checking the delivery status")
+        while is_running >= 0:
+            status= run_command(status_command)[0].rstrip()
+            is_running = re.search("New|Pending|Running",status)
+            debug_log("current status: "+status)
+            time.sleep(30)
 
-    is_complete=run_command(status_command)[0].find('Complete')
+        is_complete=run_command(status_command)[0].find('Complete')
+		//checking logs for the build phase
+        log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
+        logs = run_command(log_command)
 
-    if is_complete < 0:
-      bs.put(json.dumps(job_details))
-      debug_log("Delivery is not successful putting it to failed build tube")
+        if is_complete < 0:
+            bs.put(json.dumps(job_details))
+            notify_build_failure(name_space, notify_email, logs)
+            debug_log("Delivery is not successful putting it to failed build tube")
 
-    return 0
-  except Exception as e:
-    logger.log(level=logging.CRITICAL, msg=e.message)
-    return 1
+        return 0
+    except Exception as e:
+        logger.log(level=logging.CRITICAL, msg=e.message)
+        return 1
 
 while True:
-  try:
-    debug_log("listening to start_build tube")
-    job = bs.reserve()
-    job_details = json.loads(job.body) 
-    result = start_delivery(job_details)
-    if result == 0:
-      debug_log("Delivery is successful deleting the job")
-      job.delete()
-    else:
-      debug_log("Job was not succesfull and returned to tube")
-  except Exception as e:
-    logger.log(level=logging.CRITICAL, msg=e.message)
+    try:
+        debug_log("listening to start_build tube")
+        job = bs.reserve()
+        job_details = json.loads(job.body) 
+        result = start_delivery(job_details)
+        if result == 0:
+            debug_log("Delivery is successful deleting the job")
+            job.delete()
+        else:
+            debug_log("Job was not succesfull and returned to tube")
+    except Exception as e:
+        logger.log(level=logging.CRITICAL, msg=e.message)

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -97,6 +97,7 @@ def start_delivery(job_details):
 		//checking logs for the build phase
         log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
         logs = run_command(log_command)
+        logs = logs[0]
 
         if is_complete < 0:
             bs.put(json.dumps(job_details))

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -44,7 +44,7 @@ def debug_log(msg):
         logger.log(level=logging.INFO,msg=msg)
 
 def run_command(command):
-    p = Popen(command,bufsize=0,shelli = True,stdout = PIPE,stderr = PIPE,stdin = PIPE)
+    p = Popen(command,bufsize=0,shell = True,stdout = PIPE,stderr = PIPE,stdin = PIPE)
     p.wait()
     out = p.communicate()
     return out
@@ -95,7 +95,7 @@ def start_delivery(job_details):
 
         is_complete=run_command(status_command)[0].find('Complete')
         #checking logs for the build phase
-        log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
+        log_command = "oc logs --namespace "+name_space+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
         logs = run_command(log_command)
         logs = logs[0]
 

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -32,7 +32,7 @@ DEBUG=1
 def notify_build_failure(name_space, notify_email, logs):
     msg_details = {}
     msg_details['action'] = 'notify_user'
-    msg_details['subject'] = "Container-build failed"+namespace
+    msg_details['subject'] = "FAILED: Container-build failed"+namespace
     msg_details['msg'] = "Container build "+ namespace +" failed due to error in build or test steps. Pleae check attached logs"
     msg_details['logs'] = logs
     msg_details['to_mail'] = notify_email
@@ -95,11 +95,7 @@ def start_delivery(job_details):
 
         is_complete=run_command(status_command)[0].find('Complete')
         #checking logs for the build phase
-<<<<<<< dd68278c2b0de778c873e44ddcc7c0912a6a9863
         log_command = "oc logs --namespace "+name_space+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
-=======
-        log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
->>>>>>> Added notify_email to delivery tube
         logs = run_command(log_command)
         logs = logs[0]
 

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -32,7 +32,11 @@ DEBUG=1
 def notify_build_failure(name_space, notify_email, logs):
     msg_details = {}
     msg_details['action'] = 'notify_user'
+<<<<<<< 43da7e338eab07ee865b05ba42c6738ea96c5b2c
     msg_details['subject'] = "FAILED: Container-build failed"+namespace
+=======
+    msg_details['subject'] = "Container-build failed"+namespace
+>>>>>>> Added failure notification to delivery bit
     msg_details['msg'] = "Container build "+ namespace +" failed due to error in build or test steps. Pleae check attached logs"
     msg_details['logs'] = logs
     msg_details['to_mail'] = notify_email
@@ -44,7 +48,11 @@ def debug_log(msg):
         logger.log(level=logging.INFO,msg=msg)
 
 def run_command(command):
+<<<<<<< 43da7e338eab07ee865b05ba42c6738ea96c5b2c
     p = Popen(command,bufsize=0,shell = True,stdout = PIPE,stderr = PIPE,stdin = PIPE)
+=======
+    p = Popen(command,bufsize=0,shelli = True,stdout = PIPE,stderr = PIPE,stdin = PIPE)
+>>>>>>> Added failure notification to delivery bit
     p.wait()
     out = p.communicate()
     return out

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -94,7 +94,7 @@ def start_delivery(job_details):
             time.sleep(30)
 
         is_complete=run_command(status_command)[0].find('Complete')
-		//checking logs for the build phase
+        #checking logs for the build phase
         log_command = "oc logs --namespace "+name+"-"+tag+" build/"+build_details+" --config="+config_path+"/node.kubeconfig"
         logs = run_command(log_command)
         logs = logs[0]
@@ -111,7 +111,7 @@ def start_delivery(job_details):
 
 while True:
     try:
-        debug_log("listening to start_build tube")
+        debug_log("listening to start_delivery tube")
         job = bs.reserve()
         job_details = json.loads(job.body)
         result = start_delivery(job_details)

--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -69,6 +69,7 @@ def scan_job_data(job_data):
 
     # Receive and send `name_space` key-value as is
     namespace = job_data.get('name_space')
+    notify_email = job_data.get('notify_email')
 
     image_full_name = job_data.get('name')
     #.split(":")[0] + ":" + \
@@ -184,7 +185,8 @@ def scan_job_data(job_data):
             "msg": "Container image requires update",
             "logs": json.dumps(json_data),
             "action": "start_delivery",
-            "name_space": namespace
+            "name_space": namespace,
+            "notify_email": notify_email
         }
     else:
         d = {
@@ -192,7 +194,8 @@ def scan_job_data(job_data):
             "msg": "No updates required",
             "logs": "",
             "action": "start_delivery",
-            "name_space": namespace
+            "name_space": namespace,
+            "notify_email": notify_email
         }
     bs.use("master_tube")
     jid = bs.put(json.dumps(d))

--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -54,7 +54,7 @@ def split_logs_to_packages(list_logs):
     return package_list
 
 
-def test_job_data(job_data):
+def scan_job_data(job_data):
     msg = ""
     logs = ""
     json_data = None
@@ -175,7 +175,7 @@ def test_job_data(job_data):
     logger.log(level=logging.INFO, msg="Removing the image %s" % image_full_name)
     conn.remove_image(image=image_full_name, force=True)
 
-    logger.log(level=logging.INFO, msg="Finished test...")
+    logger.log(level=logging.INFO, msg="Finished scan...")
 
     # if msg != "" and logs != "":
     if json_data != None:
@@ -202,7 +202,7 @@ def test_job_data(job_data):
     )
 
 bs = beanstalkc.Connection(host=BEANSTALKD_HOST)
-bs.watch("start_test")
+bs.watch("start_scan")
 
 while True:
     try:
@@ -220,6 +220,7 @@ while True:
         else:
             test_job_data(job_data)
 
+        scan_job_data(job_data)
         job.delete()
     except Exception as e:
         logger.log(level=logging.FATAL, msg=e.message)

--- a/ci/README.md
+++ b/ci/README.md
@@ -17,3 +17,10 @@ url=<jenkins endpoint, e.g. https://ci.centos.org>
 ```
 jenkins-jobs update ci/job.yml
 ```
+
+## CI jobs on ci.centos.org
+
+- **[centos-container-pipeline-service-ci-master](https://ci.centos.org/view/Container/job/centos-container-pipeline-service-ci-master/)**: Runs on master branch of this repo at regular intervals.
+- **[centos-container-pipeline-service-ci-pr](https://ci.centos.org/view/Container/job/centos-container-pipeline-service-ci-pr/)**: Runs on new pull requests created to this repo. It can also be triggered manually by commenting ``#dotests`` in the pull request by the project admins.
+- **[centos-container-pipeline-service-ci-cleanup](https://ci.centos.org/view/Container/job/centos-container-pipeline-service-ci-cleanup/)**: Clean allocated resources on ci.centos.org on job success/failure
+- **[centos-container-pipeline-service-container-index](https://ci.centos.org/view/Container/job/centos-container-pipeline-service-container-index/)**: Build centos container index from https://github.com/CentOS/container-index.git

--- a/client/build-project.sh
+++ b/client/build-project.sh
@@ -69,7 +69,7 @@ IP=$(ip -f inet addr show eth1 2> /dev/null | grep 'inet' | awk '{ print $2}' | 
 #[ $? -eq 0 ] && echo -e "Build ${BUILD} started.\nYou can watch builds progress at https://${IP}:8443/console/project/${NAME}/browse/builds"
 
 echo "==> Send build configs to build tube"
-python $CWD/send_build_request.py ${NAME} ${TAG} ${DEPENDS_ON}
+python $CWD/send_build_request.py ${NAME} ${TAG} ${NOTIFY_EMAIL} ${DEPENDS_ON}
 
 echo "==> Restoring the default template"
 rm -rf $CWD/template.json

--- a/client/send_build_request.py
+++ b/client/send_build_request.py
@@ -8,7 +8,8 @@ print "Getting build details from jenkins"
 build_details = {}
 build_details['name'] = sys.argv[1]
 build_details['tag']  = sys.argv[2]
-build_details['depends_on'] = sys.argv[3]
+build_details['notify_email'] = sys.argv[3]
+build_details['depends_on'] = sys.argv[4]
 build_details['action'] = "start_build"
 
 print "Pushing bild details in the tube"

--- a/mail_service/Dockerfile.mailserv
+++ b/mail_service/Dockerfile.mailserv
@@ -1,18 +1,14 @@
-FROM centos
+FROM registry.centos.org/centos/centos:latest
 
-RUN yum -y update
-
-RUN yum -y install docker
-
-RUN yum -y install wget mailx postfix rsyslog
+RUN yum -y update && \
+    yum -y install docker && \
+    yum -y install wget mailx postfix rsyslog
 
 RUN mkdir -p /mail_service/
 
 ADD send_mail.sh /mail_service/
-
 ADD worker_notify_user.py /mail_service/
 ADD beanstalkc.py /mail_service/
-
 ADD start_mail_server.sh /mail_service/
 
 RUN chmod 777 /mail_service/*

--- a/mail_service/Dockerfile.mailserv
+++ b/mail_service/Dockerfile.mailserv
@@ -6,7 +6,9 @@ RUN yum -y update && \
 
 RUN mkdir -p /mail_service/
 
-ADD send_mail.sh /mail_service/
+ADD send_success_mail.sh /mail_service/
+ADD send_failed_mail.sh /mail_service/
+
 ADD worker_notify_user.py /mail_service/
 ADD beanstalkc.py /mail_service/
 ADD start_mail_server.sh /mail_service/

--- a/mail_service/send_failed_mail.sh
+++ b/mail_service/send_failed_mail.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mail -r container-build-report@centos.org -s "$1" $2 < $3

--- a/mail_service/send_failed_mail.sh
+++ b/mail_service/send_failed_mail.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mail -r container-build-report@centos.org -s "$1" $2 < $3
+echo $3|mail -r container-build-report@centos.org -a $4 -s "$1" $2

--- a/mail_service/send_mail.sh
+++ b/mail_service/send_mail.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo $2 | mail -r container-build-report@centos.org -s "$1" $3

--- a/mail_service/send_success_mail.sh
+++ b/mail_service/send_success_mail.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo $3 |mail -r container-build-report@centos.org -s "$1" $2

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -60,6 +60,7 @@ while True:
     else:
         logs = job_details['logs']
 
+    if ( logs)
     print "==> sending mail to user"
     send_mail(to_mail, subject, msg, logs)
 

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -60,7 +60,6 @@ while True:
     else:
         logs = job_details['logs']
 
-    if ( logs)
     print "==> sending mail to user"
     send_mail(to_mail, subject, msg, logs)
 

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -10,27 +10,36 @@ import smtplib
 bs = beanstalkc.Connection(host="172.17.0.1")
 bs.watch("notify_user")
 
-def send_mail(to_mail, subject, msg, logs)
-    SERVER = "localhost"
-    FROM = "container-build-report@centos.org"
-    TO = [to_mail] # must be a list
-    SUBJECT = subject
-    TEXT = msg+"\n"+logs
+def send_mail(to_mail, subject, msg, logs):
+    if(logs != null):
+        failed_msg_command = "/mail_service/send_failed_mail.sh"
+        logfile = open("/tmp/failed_log.log","w")
+        logfile.write(logs)
+        logfile.close()
+        subprocess.call([failed_msg_command,subject,to_mail,"/tmp/failed_log.log"])
+    else:
+        success_msg_command = "mail_service/send_success_mail.sh"
+        subprocess.call([success_msg_command,subject,to_mail,msg])
+#    SERVER = "localhost"
+#    FROM = "container-build-report@centos.org"
+#    TO = [to_mail] # must be a list
+#    SUBJECT = subject
+#    TEXT = msg+"\n"+logs
 
     # Prepare actual message
 
-    message = """\
-    From: %s
-    To: %s
-    Subject: %s
+#    message = """\
+#    From: %s
+#    To: %s
+#    Subject: %s
 
-    %s
-    """ % (FROM, ", ".join(TO), SUBJECT, TEXT)
+#    %s
+#    """ % (FROM, ", ".join(TO), SUBJECT, TEXT)
 
     # Send the mail
-    server = smtplib.SMTP(SERVER)
-    server.sendmail(FROM, TO, message)
-    server.quit()
+#    server = smtplib.SMTP(SERVER)
+#    server.sendmail(FROM, TO, message)
+#   server.quit()
 
 while True:
     print "listening to notify_user tube"

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -11,14 +11,14 @@ bs = beanstalkc.Connection(host="172.17.0.1")
 bs.watch("notify_user")
 
 def send_mail(to_mail, subject, msg, logs):
-    if(logs != null):
+    if(logs is not None):
         failed_msg_command = "/mail_service/send_failed_mail.sh"
         logfile = open("/tmp/failed_log.log","w")
         logfile.write(logs)
         logfile.close()
         subprocess.call([failed_msg_command,subject,to_mail,"/tmp/failed_log.log"])
     else:
-        success_msg_command = "mail_service/send_success_mail.sh"
+        success_msg_command = "/mail_service/send_success_mail.sh"
         subprocess.call([success_msg_command,subject,to_mail,msg])
 #    SERVER = "localhost"
 #    FROM = "container-build-report@centos.org"
@@ -50,9 +50,17 @@ while True:
     print "==> Retrieving message details"
     to_mail = job_details['to_mail']
     subject = job_details['subject']
-    msg = job_details['msg']
-    logs = job_details['logs']
+    if 'msg' not in job_details :
+        msg = None
+    else:
+        msg = job_details['msg']
 
+    if 'logs' not in job_details :
+        logs = None
+    else:
+        logs = job_details['logs']
+
+    if ( logs)
     print "==> sending mail to user"
     send_mail(to_mail, subject, msg, logs)
 

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -13,10 +13,10 @@ bs.watch("notify_user")
 def send_mail(to_mail, subject, msg, logs):
     if(logs is not None):
         failed_msg_command = "/mail_service/send_failed_mail.sh"
-        logfile = open("/tmp/failed_log.log","w")
+        logfile = open("/tmp/build_log.log","w")
         logfile.write(logs)
         logfile.close()
-        subprocess.call([failed_msg_command,subject,to_mail,"/tmp/failed_log.log"])
+        subprocess.call([failed_msg_command,subject,to_mail,msg,"/tmp/build_log.log"])
     else:
         success_msg_command = "/mail_service/send_success_mail.sh"
         subprocess.call([success_msg_command,subject,to_mail,msg])

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -42,7 +42,7 @@
     mode: u+x
   with_items:
     - ../beanstalk_worker/beanstalkc.py
-    - ../beanstalk_worker/worker_start_test.py
+    - ../beanstalk_worker/worker_start_scan.py
   when: not vagrant
 
 - name: Get service files for workers
@@ -50,16 +50,19 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:
-      - {src: "../beanstalk_worker/cccp-test-worker.service", dest: /etc/systemd/system/cccp-test-worker.service}
+      - {src: "../beanstalk_worker/cccp-scan-worker.service", dest: /etc/systemd/system/cccp-scan-worker.service}
 
-- name: Skip atomic scan for test environment
+- name: Skip atomic scan for scan environment
   replace: >
-    dest=/etc/systemd/system/cccp-test-worker.service
-    regexp='worker_start_test.py$'
-    replace='worker_start_test.py ci'
+    dest=/etc/systemd/system/cccp-scan-worker.service
+    regexp='worker_start_scan.py$'
+    replace='worker_start_scan.py ci'
   when: test
   tags:
-    - test
+    - scan
+
+- name: Enable Scanner worker
+  service: name="cccp-scan-worker" state=restarted enabled=yes
 
 - name: Add host entry for beanstalkd
   shell: echo `ping {{ groups['openshift'][0] }} -c 1 | awk '{print $3}'|head -n 1|sed 's/(//'|sed 's/)//'` openshift >> /etc/hosts
@@ -68,4 +71,4 @@
   shell: echo "127.0.0.1 atomic-scan.vm.centos.org" >> /etc/hosts
 
 - name: Enable Scanner worker
-  service: name="cccp-test-worker" state=restarted enabled=yes
+  service: name="cccp-scan-worker" state=restarted enabled=yes

--- a/server/Dockerfile.test
+++ b/server/Dockerfile.test
@@ -8,7 +8,7 @@ RUN mkdir -p /tube_request/
 
 ADD beanstalkc.py /tube_request/
 
-ADD send_test_request.py /tube_request/
+ADD send_scan_request.py /tube_request/
 
 ADD send_failed_notify_request.py /tube_request/
 

--- a/server/cccp_reader.py
+++ b/server/cccp_reader.py
@@ -9,12 +9,9 @@ def main():
   stream = open("cccp.yml",'r')
   cccp_yml = yaml.load(stream)
   stream.close()
-  
   print "==> Getting current directory"
   curr_dir = os.getcwd()
- 
   print "==> Saving scripts for build process"
- 
   got_build_script = 0;
   got_test_script = 0;
   got_delivery_script = 0;
@@ -25,20 +22,20 @@ def main():
 
     if(key == "test-skip"):
       test_skip = cccp_yml["test-skip"]
-    
+
     if(key == "build-script"):
       build_script_path = cccp_yml["build-script"]
       build_script_path = os.path.join(curr_dir,build_script_path)
       add_build_steps(target_file_path,"RUN ln -s "+build_script_path+" /usr/bin/build_script")
       got_build_script=1;
-    
+
     if(key == "test-script"):
       test_script = cccp_yml["test-script"]
       if(test_skip != True):
         test_script_path = os.path.join(curr_dir,test_script)
         add_build_steps(target_file_path,"RUN ln -s "+test_script_path+" /usr/bin/test_script")
         got_test_script=1;
-    
+
     if(key == "delivery-script"):
       delivery_script = cccp_yml["delivery-script"]
       delivery_script_path = os.path.join(curr_dir,delivery_script)

--- a/server/run-delivery.sh
+++ b/server/run-delivery.sh
@@ -25,11 +25,7 @@ docker push ${FULL_TO}
 
 OUTPUT_IMAGE=registry.centos.org/${TARGET_NAMESPACE}/${TO}
 
-#_ "Send mail to (${NOTIFY_EMAIL}) notify build is completed (${OUTPUT_IMAGE})"
-#echo "Build is successful please pull the image (${OUTPUT_IMAGE})" | mail -r container-build-report@centos.org -s "cccp-build is complete" ${NOTIFY_EMAIL}
-
-#sleep 20
-
+_ "Send success mail for user notify tube"
 python /tube_request/send_notify_request.py ${BEANSTALK_SERVER} ${OUTPUT_IMAGE} ${NOTIFY_EMAIL}
 
 _ "Cleaning environment"

--- a/server/run-delivery.sh
+++ b/server/run-delivery.sh
@@ -9,24 +9,13 @@ if [ "${TARGET_REGISTRY}" == "" ];then
     TARGET_REGISTRY=${OUTPUT_REGISTRY}
 fi
 
-#_ "Log in to the internal registry"
-#docker login -u serviceaccount -p ${TOKEN} -e serviceaccount@example.org ${OUTPUT_REGISTRY}
-
 FULL_FROM=${TARGET_REGISTRY}/${TARGET_NAMESPACE}/${FROM}
 FULL_TO=${TARGET_REGISTRY}/${TARGET_NAMESPACE}/${TO}
 
 _ "Pulling RC image (${FROM})"
 docker pull ${FULL_FROM}
 
-#_ "Running delivery steps"
-#docker run --rm ${FULL_FROM} --entrypoint /bin/bash /usr/bin/delivery_script
-
 sleep 20
-
-#_ "Starting mail server"
-#export REPLYTO=container-build@centos.org
-#mkfifo /var/spool/postfix/public/pickup
-#postfix start
 
 _ "Tagging for the public registry"
 docker tag ${FULL_FROM} ${FULL_TO}
@@ -35,11 +24,6 @@ _ "Pushing final image (${FULL_TO})"
 docker push ${FULL_TO}
 
 OUTPUT_IMAGE=registry.centos.org/${TARGET_NAMESPACE}/${TO}
-
-#_ "Send mail to (${NOTIFY_EMAIL}) notify build is completed (${OUTPUT_IMAGE})"
-#echo "Build is successful please pull the image (${OUTPUT_IMAGE})" | mail -r container-build-report@centos.org -s "cccp-build is complete" ${NOTIFY_EMAIL}
-
-#sleep 20
 
 _ "Send the image details to test_tube for testing"
 python /tube_request/send_notify_request.py ${BEANSTALK_SERVER} ${OUTPUT_IMAGE} ${NOTIFY_EMAIL}

--- a/server/run-delivery.sh
+++ b/server/run-delivery.sh
@@ -25,7 +25,11 @@ docker push ${FULL_TO}
 
 OUTPUT_IMAGE=registry.centos.org/${TARGET_NAMESPACE}/${TO}
 
-_ "Send the image details to test_tube for testing"
+#_ "Send mail to (${NOTIFY_EMAIL}) notify build is completed (${OUTPUT_IMAGE})"
+#echo "Build is successful please pull the image (${OUTPUT_IMAGE})" | mail -r container-build-report@centos.org -s "cccp-build is complete" ${NOTIFY_EMAIL}
+
+#sleep 20
+
 python /tube_request/send_notify_request.py ${BEANSTALK_SERVER} ${OUTPUT_IMAGE} ${NOTIFY_EMAIL}
 
 _ "Cleaning environment"

--- a/server/run-test.sh
+++ b/server/run-test.sh
@@ -41,7 +41,7 @@ _ "Pushing the image to registry (${OUTPUT_IMAGE})"
 #  docker push "${FULL_TO}" || jumpto sendstatusmail
 #fi
 docker push ${FULL_TO}||jumpto sendstatusmail
-python /tube_request/send_test_request.py ${BEANSTALK_SERVER} ${NS} ${OUTPUT_IMAGE} ${TEST_TAG}
+python /tube_request/send_scan_request.py ${BEANSTALK_SERVER} ${NS} ${OUTPUT_IMAGE} ${TEST_TAG} ${NOTIFY_EMAIL}
 
 
 _ "Cleaning environment"

--- a/server/send_failed_notify_request.py
+++ b/server/send_failed_notify_request.py
@@ -10,8 +10,8 @@ notify_email  = sys.argv[2]
 
 msg_details = {}
 msg_details['action'] = "notify_user"
-msg_details['subject'] = "Container-build failed"
-msg_details['msg'] = "Container build failed due to error in status of build or test steps"
+msg_details['subject'] = "FAIL: Your container build request has failed"
+msg_details['msg'] = "Build has failed."
 msg_details['to_mail'] = notify_email
 
 

--- a/server/send_notify_request.py
+++ b/server/send_notify_request.py
@@ -11,8 +11,8 @@ notify_email  = sys.argv[3]
 
 msg_details = {}
 msg_details['action'] = "notify_user"
-msg_details['subject'] = "cccp-build is complete"
-msg_details['msg'] = "Build is successful please pull the image ("+output_image+")"
+msg_details['subject'] = "SUCCESS: Your container build request is complete"
+msg_details['msg'] = "Build is successful. You can pull the image ("+output_image+")"
 msg_details['to_mail'] = notify_email
 
 

--- a/server/send_scan_request.py
+++ b/server/send_scan_request.py
@@ -10,6 +10,7 @@ image_details = {}
 image_details['name_space'] = sys.argv[2]
 image_details['name'] = sys.argv[3]
 image_details['tag']  = sys.argv[4]
+image_details['notify_email'] = sys.argv[5]
 image_details['action'] = "start_scan"
 print "Pushing image details in the tube"
 bs = beanstalkc.Connection(host=beanstalk_host)

--- a/server/send_test_request.py
+++ b/server/send_test_request.py
@@ -10,7 +10,7 @@ image_details = {}
 image_details['name_space'] = sys.argv[2]
 image_details['name'] = sys.argv[3]
 image_details['tag']  = sys.argv[4]
-image_details['action'] = "start_test"
+image_details['action'] = "start_scan"
 print "Pushing image details in the tube"
 bs = beanstalkc.Connection(host=beanstalk_host)
 bs.use("master_tube")

--- a/testindex/Engine.py
+++ b/testindex/Engine.py
@@ -1,13 +1,14 @@
-from NutsAndBolts import Environment, GlobalEnvironment
-from sys import exit
-from os import path
 from glob import glob
+from os import path
+
+from sys import exit
+
 import Validators
+from NutsAndBolts import Environment, GlobalEnvironment
 from Summary import Summary
 
 
 class Engine:
-
     def __init__(self, indexd_location="./index.d", data_dump_directory="cccp-index-test"):
 
         self._success = False

--- a/testindex/NutsAndBolts.py
+++ b/testindex/NutsAndBolts.py
@@ -1,6 +1,6 @@
-from subprocess import check_call, CalledProcessError, STDOUT
 from os import environ, path, mkdir, unsetenv, listdir, unlink, devnull
 from shutil import rmtree
+from subprocess import check_call, CalledProcessError, STDOUT
 
 
 def execute_command(cmd):
@@ -15,6 +15,7 @@ def execute_command(cmd):
 
 class Environment:
     """Handles the bringing up and teardown of the test environment"""
+
     def __init__(self, data_dump_directory="./cccp-index-test"):
 
         if not path.isabs(data_dump_directory):

--- a/testindex/Summary.py
+++ b/testindex/Summary.py
@@ -1,5 +1,7 @@
 import hashlib
+
 from yaml import dump
+
 from NutsAndBolts import GlobalEnvironment
 
 
@@ -61,7 +63,7 @@ class Summary:
 
                 if len(entry_info["warnings"]) > 0:
                     for wrn in entry_info["warnings"]:
-                        print "  **W "  +wrn
+                        print "  **W " + wrn
 
                 print "\n"
 

--- a/testindex/Validators.py
+++ b/testindex/Validators.py
@@ -63,10 +63,19 @@ class IndexFormatValidator(Validator):
                     self._success = False
                     summary_collector["errors"].append("app-id should be same as first part of the file name")
 
+                if "_" in entry["app-id"] or "/" in entry["app-id"] or "." in entry["app-id"]:
+                    self._success = False
+                    summary_collector["errors"].append("app-id cannot contain _, / or . character.")
+
             # Checking job-id field
             if "job-id" not in entry or ("job-id" in entry and entry["job-id"] is None):
                 self._success = False
                 summary_collector["errors"].append("Missing job-id field")
+
+            else:
+                if "_" in entry["job-id"] or "/" in entry["job-id"] or "." in entry["job-id"]:
+                    self._success = False
+                    summary_collector["errors"].append("job-id cannot contain _, / or . character.")
 
             # Check for git-url
             if "git-url" not in entry or ("git-url" in entry and entry["git-url"] is None):
@@ -113,7 +122,8 @@ class IndexProjectsValidator(Validator):
 
         Validator.__init__(self, index_file)
 
-    def _update_git_url(self, git_url, git_branch):
+    @staticmethod
+    def _update_git_url(git_url, git_branch):
 
         clone_path = None
 
@@ -242,7 +252,7 @@ class IndexProjectsValidator(Validator):
 
             try:
                 if value is True or value is False:
-                    h = ""
+                    pass
             except Exception:
                 self._success = False
                 summary_collector["errors"].append("test-skip should either be True or False as it is a flag")

--- a/testindex/__init__.py
+++ b/testindex/__init__.py
@@ -1,9 +1,9 @@
 from Engine import Engine
 from argparse import ArgumentParser
 
-def get_parser():
 
-    parser = ArgumentParser(description="This scirpt is used to valide the contents on the index.d directory.")
+def get_parser():
+    parser = ArgumentParser(description="This script is used to validate the contents on the index.d directory.")
 
     parser.add_argument("-d",
                         "--dump_directory",
@@ -20,6 +20,7 @@ def get_parser():
                         action="store")
 
     return parser
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
* name-space of the project for which build failed is added to subject and body of mail
* build log is attached with the mail for details of failure
* notifications are triggered from workers not directly from build steps