### PR TITLE
Added LetsEncrypt support

### DIFF
--- a/provisions/roles/nginx/templates/registry.centos.org.conf.j2
+++ b/provisions/roles/nginx/templates/registry.centos.org.conf.j2
@@ -15,7 +15,12 @@ upstream registry {
 server {
     listen      80;
     server_name registry.centos.org;
-    rewrite ^ https://registry.centos.org$request_uri? permanent;
+    location /.well-known/ {
+        proxy_pass      http://cephas.centos.org/.well-known/ ; 
+    }
+    location / {
+        rewrite        ^ https://registry.centos.org$request_uri? permanent;
+   }
 }
 
 


### PR DESCRIPTION
Added some proxy_pass to allow external/central node to be used as TLS letsencrypt client node (and not the nginx node)