### PR TITLE
Added upstream.registry.centos.org for vhost

### DIFF
--- a/provisions/roles/nginx/templates/registry.centos.org.conf.j2
+++ b/provisions/roles/nginx/templates/registry.centos.org.conf.j2
@@ -14,7 +14,7 @@ upstream registry {
 
 server {
     listen      80;
-    server_name registry.centos.org;
+    server_name registry.centos.org upstream.registry.centos.org ;
     location /.well-known/ {
         proxy_pass      http://cephas.centos.org/.well-known/ ; 
     }


### PR DESCRIPTION
Added upstream.registry.centos.org as hostname for vhost (that will permit the letsencrypt cert to be generated at the same time as for the newer registry.centos.org one)