### PR TITLE
Filters documentation files from RPM verify output

### DIFF
--- a/atomic_scanners/scanner-rpm-verify/rpm_verify.py
+++ b/atomic_scanners/scanner-rpm-verify/rpm_verify.py
@@ -123,6 +123,10 @@ class RPMVerify(object):
             if match.groups()[1] == 'c':
                 continue
 
+            # filter the documentation files
+            if match.groups()[1] == 'd':
+                continue
+
             filepath = match.groups()[2].strip()
 
             # filter the expected directories


### PR DESCRIPTION
 Like configuration files, the documentation files are also now filtered.
 With documentation files in image, the image size increases, by removing
 the documentation files from RPM installed files, image size decreases.