### PR TITLE
Fix ci builds

### DIFF
--- a/ci/cccp_ci_container_index.sh
+++ b/ci/cccp_ci_container_index.sh
@@ -1,0 +1,13 @@
+# copied from the devtools repo
+set +e
+export CICO_API_KEY=$(cat ~/duffy.key )
+read CICO_hostname CICO_ssid <<< $(cico node get -f value -c ip_address -c comment)
+sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+ssh_cmd="ssh $sshopts $CICO_hostname"
+$ssh_cmd "yum -y install epel-release && yum -y install rsync git PyYAML python-networkx"
+rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
+$ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
+$ssh_cmd /usr/bin/python container-pipeline-service/testindex/__init__.py  -i payload/index.d
+rtn_code=$?
+cico node done $CICO_ssid
+exit $rtn_code

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -1,8 +1,8 @@
 - builder:
     name: centos-container-pipeline-service-ci-builders
     builders:
-        - shell:
-            !include-raw './setup_env.sh'
+        - shell: |
+            sh ./ci/setup_env.sh
         - inject:
             properties-file: env.properties
         - shell: |
@@ -163,16 +163,4 @@
     builders:
         - git-fast-forward-branch
         - shell: |
-            # copied from the devtools repo
-            set +e
-            export CICO_API_KEY=$(cat ~/duffy.key )
-            read CICO_hostname CICO_ssid <<< $(cico node get -f value -c ip_address -c comment)
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
-            ssh_cmd="ssh $sshopts $CICO_hostname"
-            $ssh_cmd "yum -y install epel-release && yum -y install rsync git PyYAML python-networkx"
-            rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            $ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
-            $ssh_cmd /usr/bin/python container-pipeline-service/testindex/__init__.py  -i payload/index.d
-            rtn_code=$?
-            cico node done $CICO_ssid
-            exit $rtn_code
+            sh ./ci/cccp_ci_container_index.sh

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -6,7 +6,6 @@
         - inject:
             properties-file: env.properties
         - shell: |
-            export PYTHONPATH=${PYTHONPATH:-"$(pwd):$PYTHONPATH"}
             python ./ci/cccp_ci.py
 
 - builder:

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -4,8 +4,7 @@ fi
 touch env.properties
 echo "URL_BASE=http://admin.ci.centos.org:8080" >> env.properties
 echo "API=$(cat ~/duffy.key)" >> env.properties
+echo "PYTHONPATH=$(pwd):$PYTHONPATH" >> env.properties
 
 bash provisions/utils/gencert.sh registry.centos.org || true
 echo -e  'y\n'| ssh-keygen -t rsa -N "" -f provisions/jenkins.key
-
-export PYTHONPATH=$(pwd):$PYTHONPATH


### PR DESCRIPTION
This implements:

- build failures in CICO due to missing PYTHONPATH
- move inline build scripts from  JJB file to external files