### PR TITLE
Delete job if scanner data is too big

### DIFF
--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -433,5 +433,11 @@ while True:
             msg="Job moved from scan phase, id: %s" % job_id
             )
         job.delete()
+    except beanstalkc.CommandFailed as e:
+        logger.log(
+            level=logging.ERROR,
+            msg="Failed to put scanner data on beanstalkd tube; deleting job"
+        )
+        job.delete()
     except Exception as e:
         logger.log(level=logging.FATAL, msg=str(e))


### PR DESCRIPTION
This is a temporary fix till the time we modify the workers to use NFS volumes to store data instead of sending it over the beanstalkd tube.

Need PR review; ping @rtnpro @bamachrn @mohammedzee1000 @navidshaikh 