### PR TITLE
WIP - Update linter image before execution

### DIFF
--- a/beanstalk_worker/constants.py
+++ b/beanstalk_worker/constants.py
@@ -6,3 +6,5 @@ SCANNERS_OUTPUT = {
         "registry.centos.org/pipeline-images/scanner-rpm-verify": [
             "RPMVerify.json"]
 }
+
+LINTER_IMAGE = "registry.centos.org/pipeline-images/dockerfile-lint"

--- a/beanstalk_worker/worker_dockerfile_lint.py
+++ b/beanstalk_worker/worker_dockerfile_lint.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 import sys
 
+from constants import LINTER_IMAGE
+
 logger = logging.getLogger("cccp-linter")
 logger.setLevel(logging.DEBUG)
 
@@ -44,12 +46,14 @@ def lint_job_data(job_data):
 
     logger.log(level=logging.INFO, msg="Running Dockerfile Lint check")
     out, err = subprocess.Popen(
-        ["docker",
-         "run",
-         "--rm",
-         "-v",
-         "/tmp/scan:/root/scan:Z",
-         "registry.centos.org/pipeline-images/dockerfile-lint"],
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            "/tmp/scan:/root/scan:Z",
+            LINTER_IMAGE
+        ],
         stdout=subprocess.PIPE
     ).communicate()
 


### PR DESCRIPTION
In this PR, we're modifying the Dockerfile lint worker to pull in the linter image right before linting the Dockerfile. This should ensure we have a latest image every time.