### PR TITLE
Fix list index out of range issue in delivery worker

### DIFF
--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -86,7 +86,7 @@ def start_delivery(job_details):
         out = run_command(command_start_build)
         debug_log(out)
 
-        build_details = out[0].split('"')[1].rstrip()
+        build_details = out[0].split('"')[-1].rstrip()
         debug_log(build_details)
 
         if build_details == "":


### PR DESCRIPTION
  With openshift v1.2.1 , the output on stdout has changed.
  Earlier we were using openshift v1.3, and code was written according to it.
  With fixes needed for CI, we started using openshift v1.2.1, and this code change
  is needed to make code work with openshift v1.2.1