### PR TITLE
Modifies linter and build logs extention to .txt

### DIFF
--- a/beanstalk_worker/constants.py
+++ b/beanstalk_worker/constants.py
@@ -16,7 +16,7 @@ SCANNERS_RESULTFILE = {
             "RPMVerify_scanner_results.json"]
 }
 
-LINTER_RESULTFILE = "linter_results.log"
+LINTER_RESULTFILE = "linter_results.txt"
 
 LOGS_URL_BASE= "https://registry.centos.org/pipeline-logs/"
 LOGS_DIR = "/srv/pipeline-logs/"

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -95,7 +95,7 @@ def start_build(job_details):
         # This will be a mounted directory
         build_logs_file = os.path.join(
                 job_details["logs_dir"],
-                "build_logs.log"
+                "build_logs.txt"
                 )
 
         debug_log("Login to OpenShift server")

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -11,7 +11,7 @@ bs.watch("notify_user")
 def send_mail(notify_email, subject, msg, logs):
     if(logs is not None):
         failed_msg_command = "/mail_service/send_failed_mail.sh"
-        logfile = open("/tmp/build_log.log", "w")
+        logfile = open("/tmp/build_logs.txt", "w")
         logfile.write(logs)
         logfile.close()
         subprocess.call(
@@ -19,7 +19,7 @@ def send_mail(notify_email, subject, msg, logs):
              subject,
              notify_email,
              msg,
-             "/tmp/build_log.log"])
+             "/tmp/build_logs.txt"])
     else:
         success_msg_command = "/mail_service/send_success_mail.sh"
         # escape the \ with \\ for rendering in email

--- a/server/send_notify_request.py
+++ b/server/send_notify_request.py
@@ -10,7 +10,7 @@ output_image = sys.argv[2]
 notify_email = sys.argv[3]
 TEST_TAG = sys.argv[4]
 BUILD_LOGS_URL = "https://registry.centos.org/pipeline-logs/" + \
-        TEST_TAG + "/build_logs.log"
+        TEST_TAG + "/build_logs.txt"
 
 msg_details = {}
 msg_details['action'] = "notify_user"


### PR DESCRIPTION
  Fixes #179 #180

  linter and build logs filename has .log extension, browser does not
  render them but starts the download of the file. This commit updates
  extension to .txt , with NFS configured for logs, users are notified
  over email with links to all the logs, with .txt extension, users can
  check the logs right in brower tab than downloading them before opening.