### PR TITLE
Fixed project naming for desired tag with dots.

### DIFF
--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import beanstalkc
+import binascii
 import json
 from subprocess import Popen
 from subprocess import PIPE
@@ -9,7 +10,6 @@ import time
 import logging
 import sys
 import os
-import base64
 
 bs = beanstalkc.Connection(host="BEANSTALK_SERVER")
 bs.watch("start_build")
@@ -90,7 +90,10 @@ def start_build(job_details):
         appid = job_details['appid']
         jobid = job_details['jobid']
         desired_tag = job_details['desired_tag']
-        namespace = base64.b64encode(str(appid) + str(jobid) + str(desired_tag))
+        pre_namespace = str(appid) + str(jobid) + str(desired_tag)
+        namespace = binascii.hexlify(pre_namespace)
+        debug_log("Openshift project namespace hexlified from {0} to {1} can be hash can be reproduced with xxd tool"
+                  .format(pre_namespace, namespace))
         #depends_on = job_details['depends_on']
         notify_email = job_details['notify_email']
         # This will be a mounted directory

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -90,6 +90,7 @@ def start_build(job_details):
         jobid = job_details['jobid']
         desired_tag = job_details['desired_tag']
         namespace = appid + "-" + jobid + "-" + desired_tag
+        namespace = namespace.replace(".", "-")
         #depends_on = job_details['depends_on']
         notify_email = job_details['notify_email']
         # This will be a mounted directory

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import beanstalkc
-import binascii
+from binascii import hexlify
 import json
 from subprocess import Popen
 from subprocess import PIPE
@@ -90,8 +90,8 @@ def start_build(job_details):
         appid = job_details['appid']
         jobid = job_details['jobid']
         desired_tag = job_details['desired_tag']
-        pre_namespace = str(appid) + str(jobid) + str(desired_tag)
-        namespace = binascii.hexlify(pre_namespace)
+        pre_namespace = str(appid) + "-" + str(jobid) + "-" + str(desired_tag)
+        namespace = hexlify(pre_namespace)
         debug_log("Openshift project namespace hexlified from {0} to {1} can be hash can be reproduced with xxd tool"
                   .format(pre_namespace, namespace))
         #depends_on = job_details['depends_on']

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -9,6 +9,7 @@ import time
 import logging
 import sys
 import os
+import base64
 
 bs = beanstalkc.Connection(host="BEANSTALK_SERVER")
 bs.watch("start_build")
@@ -89,8 +90,7 @@ def start_build(job_details):
         appid = job_details['appid']
         jobid = job_details['jobid']
         desired_tag = job_details['desired_tag']
-        namespace = appid + "-" + jobid + "-" + desired_tag
-        namespace = namespace.replace(".", "-")
+        namespace = base64.b64encode(str(appid) + str(jobid) + str(desired_tag))
         #depends_on = job_details['depends_on']
         notify_email = job_details['notify_email']
         # This will be a mounted directory

--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -92,7 +92,7 @@ def start_build(job_details):
         desired_tag = job_details['desired_tag']
         pre_namespace = str(appid) + "-" + str(jobid) + "-" + str(desired_tag)
         namespace = hexlify(pre_namespace)
-        debug_log("Openshift project namespace hexlified from {0} to {1} can be hash can be reproduced with xxd tool"
+        debug_log("Openshift project namespace hexlified from {0} to {1}, hash can be reproduced with xxd tool"
                   .format(pre_namespace, namespace))
         #depends_on = job_details['depends_on']
         notify_email = job_details['notify_email']

--- a/ci/tests/test_00_openshift/__init__.py
+++ b/ci/tests/test_00_openshift/__init__.py
@@ -16,7 +16,7 @@ class TestOpenshift(BaseTestCase):
             "oc login https://{openshift}:8443 "
             "--insecure-skip-tls-verify=true "
             "-u test-admin -p test > /dev/null && "
-            "oc project YmFtYWNocm5weXRob25yZWxlYXNl > /dev/null && "
+            "oc project 62616d616368726e707974686f6e72656c65617365 > /dev/null && "
             "oc get pods"
         ).format(openshift=self.hosts[self.node]['host'])
         self.run_cmd(cmd)
@@ -53,7 +53,7 @@ class TestOpenshift(BaseTestCase):
         cmd = (
             "oc login https://%s:8443 --insecure-skip-tls-verify=true "
             "-u test-admin -p test > /dev/null && "
-            "oc project YmFtYWNocm5weXRob25yZWxlYXNl > /dev/null && "
+            "oc project 62616d616368726e707974686f6e72656c65617365 > /dev/null && "
             "oc get pods"
         ) % (self.hosts["openshift"]["host"])
         output = self.run_cmd(cmd)

--- a/ci/tests/test_00_openshift/__init__.py
+++ b/ci/tests/test_00_openshift/__init__.py
@@ -16,7 +16,7 @@ class TestOpenshift(BaseTestCase):
             "oc login https://{openshift}:8443 "
             "--insecure-skip-tls-verify=true "
             "-u test-admin -p test > /dev/null && "
-            "oc project bamachrn-python-release > /dev/null && "
+            "oc project YmFtYWNocm5weXRob25yZWxlYXNl > /dev/null && "
             "oc get pods"
         ).format(openshift=self.hosts[self.node]['host'])
         self.run_cmd(cmd)
@@ -53,7 +53,7 @@ class TestOpenshift(BaseTestCase):
         cmd = (
             "oc login https://%s:8443 --insecure-skip-tls-verify=true "
             "-u test-admin -p test > /dev/null && "
-            "oc project bamachrn-python-release > /dev/null && "
+            "oc project YmFtYWNocm5weXRob25yZWxlYXNl > /dev/null && "
             "oc get pods"
         ) % (self.hosts["openshift"]["host"])
         output = self.run_cmd(cmd)

--- a/ci/tests/test_00_openshift/__init__.py
+++ b/ci/tests/test_00_openshift/__init__.py
@@ -16,7 +16,7 @@ class TestOpenshift(BaseTestCase):
             "oc login https://{openshift}:8443 "
             "--insecure-skip-tls-verify=true "
             "-u test-admin -p test > /dev/null && "
-            "oc project 62616d616368726e707974686f6e72656c65617365 > /dev/null && "
+            "oc project 62616d616368726e2d707974686f6e2d72656c65617365 > /dev/null && "
             "oc get pods"
         ).format(openshift=self.hosts[self.node]['host'])
         self.run_cmd(cmd)
@@ -53,7 +53,7 @@ class TestOpenshift(BaseTestCase):
         cmd = (
             "oc login https://%s:8443 --insecure-skip-tls-verify=true "
             "-u test-admin -p test > /dev/null && "
-            "oc project 62616d616368726e707974686f6e72656c65617365 > /dev/null && "
+            "oc project 62616d616368726e2d707974686f6e2d72656c65617365 > /dev/null && "
             "oc get pods"
         ) % (self.hosts["openshift"]["host"])
         output = self.run_cmd(cmd)

--- a/client/build_project.sh
+++ b/client/build_project.sh
@@ -46,8 +46,7 @@ LOGS_DIR="/srv/pipeline-logs/$TEST_TAG"
 
 
 CWD=`dirname $0`
-printf "${APPID}${JOBID}${DESIRED_TAG}" | base64
-PN="`printf "${APPID}${JOBID}${DESIRED_TAG}" | base64`"
+PN=`python -c "import binascii;print binascii.hexlify('${APPID}${JOBID}${DESIRED_TAG}')"`
 NS="--namespace ${PN}"
 
 echo "==> login to Openshift server"

--- a/client/build_project.sh
+++ b/client/build_project.sh
@@ -45,7 +45,7 @@ LOGS_DIR="/srv/pipeline-logs/$TEST_TAG"
 
 
 CWD=`dirname $0`
-PN=`python -c "from binascii hexlify;print hexlify('${APPID}-${JOBID}-${DESIRED_TAG}')"`
+PN=`python -c "from binascii import hexlify;print hexlify('${APPID}-${JOBID}-${DESIRED_TAG}')"`
 NS="--namespace ${PN}"
 
 echo "==> login to Openshift server"

--- a/client/build_project.sh
+++ b/client/build_project.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/bash
 
 ADMIN="--config=/var/lib/origin/openshift.local.config/master/admin.kubeconfig"
-TMP_FILE="./tmp_file"
 
 
 function usage() {
@@ -46,7 +45,7 @@ LOGS_DIR="/srv/pipeline-logs/$TEST_TAG"
 
 
 CWD=`dirname $0`
-PN=`python -c "import binascii;print binascii.hexlify('${APPID}${JOBID}${DESIRED_TAG}')"`
+PN=`python -c "from binascii hexlify;print hexlify('${APPID}-${JOBID}-${DESIRED_TAG}')"`
 NS="--namespace ${PN}"
 
 echo "==> login to Openshift server"

--- a/client/build_project.sh
+++ b/client/build_project.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 ADMIN="--config=/var/lib/origin/openshift.local.config/master/admin.kubeconfig"
+TMP_FILE="./tmp_file"
 
 
 function usage() {
@@ -45,7 +46,8 @@ LOGS_DIR="/srv/pipeline-logs/$TEST_TAG"
 
 
 CWD=`dirname $0`
-PN="${APPID}-${JOBID}-${DESIRED_TAG}"
+echo "${APPID}-${JOBID}-${DESIRED_TAG}" > ${TMP_FILE}
+PN="`sed -e "s/\./-/g" ${TMP_FILE}`"
 NS="--namespace ${PN}"
 
 echo "==> login to Openshift server"

--- a/client/build_project.sh
+++ b/client/build_project.sh
@@ -46,8 +46,8 @@ LOGS_DIR="/srv/pipeline-logs/$TEST_TAG"
 
 
 CWD=`dirname $0`
-echo "${APPID}-${JOBID}-${DESIRED_TAG}" > ${TMP_FILE}
-PN="`sed -e "s/\./-/g" ${TMP_FILE}`"
+printf "${APPID}${JOBID}${DESIRED_TAG}" | base64
+PN="`printf "${APPID}${JOBID}${DESIRED_TAG}" | base64`"
 NS="--namespace ${PN}"
 
 echo "==> login to Openshift server"

--- a/server/run-test.sh
+++ b/server/run-test.sh
@@ -35,8 +35,7 @@ docker pull ${FULL_FROM} || jumpto sendstatusmail
 
 _ "Re-tagging tested image (${FULL_FROM} -> ${FULL_TO})"
 docker tag ${FULL_FROM} ${FULL_TO} || jumpto sendstatusmail
-printf "${APPID}${JOBID}${DESIRED_TAG}" | base64
-NS="`printf "${APPID}${JOBID}${DESIRED_TAG}" | base64`"
+NS=`python -c "import binascii;print binascii.hexlify('${APPID}${JOBID}${DESIRED_TAG}')"`
 OUTPUT_IMAGE=${TARGET_REGISTRY}/${APPID}/${TO}
 
 _ "Pushing the image to registry (${OUTPUT_IMAGE})"

--- a/server/run-test.sh
+++ b/server/run-test.sh
@@ -35,7 +35,7 @@ docker pull ${FULL_FROM} || jumpto sendstatusmail
 
 _ "Re-tagging tested image (${FULL_FROM} -> ${FULL_TO})"
 docker tag ${FULL_FROM} ${FULL_TO} || jumpto sendstatusmail
-NS=`python -c "import binascii;print binascii.hexlify('${APPID}${JOBID}${DESIRED_TAG}')"`
+NS=`python -c "from binascii import hexlify;print hexlify('${APPID}-${JOBID}-${DESIRED_TAG}')"`
 OUTPUT_IMAGE=${TARGET_REGISTRY}/${APPID}/${TO}
 
 _ "Pushing the image to registry (${OUTPUT_IMAGE})"

--- a/server/run-test.sh
+++ b/server/run-test.sh
@@ -2,7 +2,6 @@
 
 NFS_SHARE="/srv/pipeline-logs"
 LOGS_DIR="${NFS_SHARE}/${TEST_TAG}"
-TMP_FILE="./tmp_file"
 
 function _() {
     echo "==> $@"
@@ -36,9 +35,8 @@ docker pull ${FULL_FROM} || jumpto sendstatusmail
 
 _ "Re-tagging tested image (${FULL_FROM} -> ${FULL_TO})"
 docker tag ${FULL_FROM} ${FULL_TO} || jumpto sendstatusmail
-
-echo "${APPID}-${JOBID}-${DESIRED_TAG}" > ${TMP_FILE}
-NS="`sed -e "s/\./-/g" ${TMP_FILE}`"
+printf "${APPID}${JOBID}${DESIRED_TAG}" | base64
+NS="`printf "${APPID}${JOBID}${DESIRED_TAG}" | base64`"
 OUTPUT_IMAGE=${TARGET_REGISTRY}/${APPID}/${TO}
 
 _ "Pushing the image to registry (${OUTPUT_IMAGE})"

--- a/server/run-test.sh
+++ b/server/run-test.sh
@@ -2,6 +2,7 @@
 
 NFS_SHARE="/srv/pipeline-logs"
 LOGS_DIR="${NFS_SHARE}/${TEST_TAG}"
+TMP_FILE="./tmp_file"
 
 function _() {
     echo "==> $@"
@@ -36,7 +37,8 @@ docker pull ${FULL_FROM} || jumpto sendstatusmail
 _ "Re-tagging tested image (${FULL_FROM} -> ${FULL_TO})"
 docker tag ${FULL_FROM} ${FULL_TO} || jumpto sendstatusmail
 
-NS=${APPID}-${JOBID}-${DESIRED_TAG}
+echo "${APPID}-${JOBID}-${DESIRED_TAG}" > ${TMP_FILE}
+NS="`sed -e "s/\./-/g" ${TMP_FILE}`"
 OUTPUT_IMAGE=${TARGET_REGISTRY}/${APPID}/${TO}
 
 _ "Pushing the image to registry (${OUTPUT_IMAGE})"


### PR DESCRIPTION
When desired tag has dots, the project name also has the same
as it is appid-jobid-desired tag. This fails project creation
as openshift project names cannot have dots.
Added logic to relplace the same wherever project name was
being used.