### PR TITLE
Removed p.wait as it can cause deadlock with piped Popen.

### DIFF
--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -41,7 +41,7 @@ def run_command(command):
     try:
         p = Popen(command, bufsize=0, shell=True,
               stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        p.wait()
+        #p.wait()
         out,err = p.communicate()
         return out
     except Exception as e:

--- a/beanstalk_worker/worker_start_delivery.py
+++ b/beanstalk_worker/worker_start_delivery.py
@@ -52,7 +52,7 @@ def run_command(command):
     try:
         p = Popen(command, bufsize=0, shell=True,
                   stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        p.wait()
+        #p.wait()
         out = p.communicate()
         return out
     except Exception as e:


### PR DESCRIPTION
Refer https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait
This happens in especially large builds.