### PR TITLE
Options in host.sample file to configure NFS on dev env

### DIFF
--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -22,6 +22,11 @@ public_registry=jenkins-slave
 beanstalk_server=openshift
 rsync_ssh_opts=""
 
+## dev environment options, update following to configure NFS
+#test=True
+# replace scanner_worker below with its FQDN / IP
+#test_nfs_share= scanner_worker:/nfsshare
+
 [jenkins_master:vars]
 # update as needed
 oc_slave=jenkins-slave


### PR DESCRIPTION
  as it is done in CI, by keeping test=True, we configure NFS for
  nodes of test environemnt, same can be done if we update hosts.sample
  file for dev environment. The dev wont need to configure NFS.
  Scanner node is selected as NFS server, while other 3 nodes and scanner node
  (as client) point to it.