### PR TITLE
Hot-fix to delete a build job even in case of failure

### DIFF
--- a/beanstalk_worker/worker_start_build.py
+++ b/beanstalk_worker/worker_start_build.py
@@ -172,10 +172,11 @@ while True:
             job = bs.reserve()
             job_details = json.loads(job.body)
             result = start_build(job_details)
-            job.delete()
         else:
             debug_log("No job found to process looping again")
             time.sleep(DELAY)
     except Exception as e:
         logger.log(level=logging.CRITICAL, msg=e.message)
         time.sleep(DELAY)
+    finally:
+        job.delete()


### PR DESCRIPTION
For time being, delete the job from tube if it fails to build an image. This is to ensure that end user is not bombarded with few hundred e-mails in matter of hours.