### PR TITLE
Added script to setup, test in devcloud.

### DIFF
--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -13,7 +13,7 @@ import os
 import urllib
 import sys
 
-from ci.lib import _print, run_cmd, provision
+from ci.lib import _print, setup, test, teardown
 
 url_base = os.environ.get('URL_BASE')
 api = os.environ.get('API')
@@ -23,10 +23,10 @@ arch = "x86_64"
 count = 4
 NFS_SHARE = "/nfsshare"
 
-repo_url = os.environ.get('ghprbAuthorRepoGitUrl') or \
-    os.environ.get('GIT_URL')
-repo_branch = os.environ.get('ghprbSourceBranch') or \
-    os.environ.get('ghprbTargetBranch') or 'master'
+# repo_url = os.environ.get('ghprbAuthorRepoGitUrl') or \
+#     os.environ.get('GIT_URL')
+# repo_branch = os.environ.get('ghprbSourceBranch') or \
+#     os.environ.get('ghprbTargetBranch') or 'master'
 
 
 def get_nodes(ver="7", arch="x86_64", count=4):
@@ -51,154 +51,14 @@ def print_nodes():
     _print('\n'.join(s.splitlines()[3:]))
 
 
-def generate_ansible_inventory(jenkins_master_host, jenkins_slave_host,
-                               openshift_host, scanner_host):
-
-    test_nfs_share = scanner_host + ":" + NFS_SHARE
-
-    ansible_inventory = ("""
-[all:children]
-jenkins_master
-jenkins_slaves
-openshift
-scanner_worker
-
-[jenkins_master]
-{jenkins_master_host}
-
-[jenkins_slaves]
-{jenkins_slave_host}
-
-[openshift]
-{openshift_host}
-
-[scanner_worker]
-{scanner_host}
-
-[all:vars]
-public_registry= {jenkins_slave_host}
-copy_ssl_certs=True
-openshift_startup_delay=150
-beanstalk_server={openshift_host}
-test=True
-cccp_source_repo={repo_url}
-cccp_source_branch={repo_branch}
-jenkins_public_key_file = jenkins.key.pub
-enable_epel=False
-test_nfs_share={test_nfs_share}
-
-[jenkins_master:vars]
-jenkins_private_key_file = jenkins.key
-cccp_index_repo=https://github.com/rtnpro/container-index.git
-oc_slave={jenkins_slave_host}""").format(
-        jenkins_master_host=jenkins_master_host,
-        jenkins_slave_host=jenkins_slave_host,
-        openshift_host=openshift_host,
-        repo_url=repo_url,
-        repo_branch=repo_branch,
-        scanner_host=scanner_host,
-        test_nfs_share=test_nfs_share)
-
-    with open('hosts', 'w') as f:
-        f.write(ansible_inventory)
-
-    print test_nfs_share
-
-def setup_controller(controller):
-    # provision controller
-    run_cmd(
-        "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "
-        "~/.ssh/id_rsa root@%s:/root/.ssh/id_rsa" % controller
-    )
-
-    run_cmd(
-        "yum install -y git && "
-        "yum install -y python-virtualenv && "
-        "yum install -y gcc libffi-devel python-devel openssl-devel && "
-        "virtualenv venv && "
-        "$HOME/venv/bin/pip install ansible==2.2.1 && "
-        "ln -s $HOME/venv/bin/ansible-playbook /usr/bin/ansible-playbook",
-        host=controller)
-
-    run_cmd(
-        "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r "
-        "./ root@%s:/root/container-pipeline-service" % controller)
-
-
-def run():
-    os.environ.pop('CCCP_CI_PROVISIONED', None)
-    os.environ.pop('CCCP_CI_HOSTS', None)
-
-    nodes = get_nodes(count=5)
-
-    jenkins_master_host = nodes[0]
-    jenkins_slave_host = nodes[1]
-    openshift_host = nodes[2]
-    scanner_host = nodes[3]
-    controller = nodes.pop()
-
-    nodes_env = (
-        "\nJENKINS_MASTER_HOST=%s\n"
-        "JENKINS_SLAVE_HOST=%s\n"
-        "OPENSHIFT_HOST=%s\n"
-        "CONTROLLER=%s\n"
-        "SCANNER_HOST=%s\n"
-    ) % (jenkins_master_host, jenkins_slave_host,
-         openshift_host, controller, scanner_host)
-
-    with open('env.properties', 'a') as f:
-        f.write(nodes_env)
-
-    hosts_data = {
-        'openshift': {
-            'host': openshift_host,
-            'remote_user': 'root'
-        },
-        'jenkins_master': {
-            'host': jenkins_master_host,
-            'remote_user': 'root'
-        },
-        'jenkins_slave': {
-            'host': jenkins_slave_host,
-            'remote_user': 'root'
-        },
-        'controller': {
-            'host': controller,
-            'user': 'root',
-            'workdir': '/root/container-pipeline-service',
-            # relative to this workdir
-            'inventory_path': 'hosts'
-        }
-    }
-
-    _print(hosts_data)
-
-    generate_ansible_inventory(jenkins_master_host,
-                               jenkins_slave_host,
-                               openshift_host,
-                               scanner_host)
-
-    run_cmd('iptables -F', host=openshift_host)
-    run_cmd('iptables -F', host=jenkins_slave_host)
-    run_cmd('setenforce 0', host=openshift_host)
-
-    setup_controller(controller)
-
-    provision(hosts_data['controller'])
-
-    os.environ['CCCP_CI_PROVISIONED'] = "true"
-
-    os.environ['CCCP_CI_HOSTS'] = json.dumps(hosts_data)
-
-    run_cmd('~/venv/bin/nosetests ci/tests', stream=True)
-
-    os.environ.pop('CCCP_CI_PROVISIONED', None)
-    os.environ.pop('CCCP_CI_HOSTS', None)
-
-
 if __name__ == '__main__':
     try:
-        run()
+        nodes = get_nodes(count=5)
+        data = setup(nodes, options={
+            'nfs_share': NFS_SHARE
+        })
+        test(data)
+        teardown()
     except Exception as e:
         _print('Build failed: %s' % e)
         if DEBUG:

--- a/ci/devcloud_ci.py
+++ b/ci/devcloud_ci.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import os
+import sys
+import getpass
+import json
+
+from ci.lib import setup, test, teardown, run_cmd, sync_controller
+
+HELP_MESSAGE = """
+Usage:
+# Setup
+devcloud_ci.py setup <jenkins_master_vm_id> \
+<jenkins_slave_vm_id> \
+<openshift_vm_id> \
+<scanner_host_vm_id> \
+<controller_vm_id>
+
+# test
+devcloud_ci.py test
+
+# teardown
+devcloud_ci.py teardown
+"""
+
+if __name__ == '__main__':
+    sys.path.append(
+        os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..')
+        )
+    )
+    argc = len(sys.argv)
+    if argc == 1 or argc > 1 and '-h' in sys.argv:
+        print HELP_MESSAGE
+        sys.exit(0)
+    elif sys.argv[1] not in ('setup', 'test', 'teardown', 'sync'):
+        print HELP_MESSAGE
+        sys.exit(0)
+    cmd = sys.argv[1]
+    if cmd == 'setup':
+        cmd_str = 'onevm show %s | grep -i eth0_ip | cut -d "\\"" -f 2'
+        user = getpass.getuser()
+        nodes = [run_cmd(cmd_str % vmid, user=user).strip()
+                 for vmid in sys.argv[2:7]]
+        data = setup(nodes, options={
+            'nfs_share': '/nfsshare'
+        })
+        with open('test.json', 'w') as f:
+            f.write(json.dumps(data))
+    elif cmd == 'test':
+        test_path = ' '.join(sys.argv[2:]) if argc > 2 else ''
+        with open('test.json') as f:
+            data = json.load(f)
+        test(data, test_path)
+    elif cmd == 'teardown':
+        teardown()
+    elif cmd == 'sync':
+        with open('test.json') as f:
+            data = json.load(f)
+            controller = data['hosts']['controller']['host']
+        sync_controller(controller, stream=True)

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -202,6 +202,8 @@ def setup_controller(controller):
         "yum install -y rsync && "
         "yum install -y python-virtualenv && "
         "yum install -y gcc libffi-devel python-devel openssl-devel && "
+        "yum install -y epel-release && "
+        "yum install -y PyYAML python-networkx && "
         "virtualenv venv && "
         "$HOME/venv/bin/pip install ansible==2.2.1 && "
         "ln -s $HOME/venv/bin/ansible-playbook /usr/bin/ansible-playbook || "

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -1,12 +1,12 @@
 import subprocess
 import os
 import sys
+import json
 
-url_base = os.environ.get('URL_BASE')
-api = os.environ.get('API')
-ver = "7"
-arch = "x86_64"
-count = 4
+PROJECT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__),
+                 '..')
+)
 
 
 def _print(msg):
@@ -93,3 +93,172 @@ class ProvisionHandler(object):
         self._provisioned = True
 
 provision = ProvisionHandler().run
+
+
+def generate_ansible_inventory(jenkins_master_host, jenkins_slave_host,
+                               openshift_host, scanner_host, nfs_share):
+
+    test_nfs_share = scanner_host + ":" + nfs_share
+
+    ansible_inventory = ("""
+[all:children]
+jenkins_master
+jenkins_slaves
+openshift
+scanner_worker
+
+[jenkins_master]
+{jenkins_master_host}
+
+[jenkins_slaves]
+{jenkins_slave_host}
+
+[openshift]
+{openshift_host}
+
+[scanner_worker]
+{scanner_host}
+
+[all:vars]
+public_registry= {jenkins_slave_host}
+copy_ssl_certs=True
+openshift_startup_delay=150
+beanstalk_server={openshift_host}
+test=True
+jenkins_public_key_file = jenkins.key.pub
+enable_epel=False
+test_nfs_share={test_nfs_share}
+
+[jenkins_master:vars]
+jenkins_private_key_file = jenkins.key
+cccp_index_repo=https://github.com/rtnpro/container-index.git
+oc_slave={jenkins_slave_host}""").format(
+        jenkins_master_host=jenkins_master_host,
+        jenkins_slave_host=jenkins_slave_host,
+        openshift_host=openshift_host,
+        scanner_host=scanner_host,
+        test_nfs_share=test_nfs_share)
+
+    with open(os.path.join(PROJECT_DIR, 'hosts'), 'w') as f:
+        f.write(ansible_inventory)
+
+    print test_nfs_share
+
+
+def setup_ssh_access(from_node, to_nodes):
+    run_cmd('rm -f ~/.ssh/id_rsa* && '
+            'ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa',
+            host=from_node)
+    pub_key = run_cmd('cat ~/.ssh/id_rsa.pub', host=from_node).strip()
+    for node in to_nodes:
+        run_cmd(
+            'echo "%s" >> ~/.ssh/authorized_keys' % pub_key,
+            host=node)
+
+
+def sync_controller(controller, stream=False):
+    run_cmd(
+        "rsync -auvr --delete "
+        "-e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' "
+        "%s/ root@%s:/root/container-pipeline-service" % (
+            PROJECT_DIR, controller), stream=stream)
+
+
+def setup_controller(controller):
+    # provision controller
+    run_cmd(
+        "yum install -y git && "
+        "yum install -y python-virtualenv && "
+        "yum install -y gcc libffi-devel python-devel openssl-devel && "
+        "virtualenv venv && "
+        "$HOME/venv/bin/pip install ansible==2.2.1 && "
+        "ln -s $HOME/venv/bin/ansible-playbook /usr/bin/ansible-playbook || "
+        "true && "
+        "$HOME/venv/bin/pip install nose && "
+        "ln -s $HOME/venv/bin/nosetests /usr/bin/nosetests || true",
+        host=controller)
+
+
+def setup(nodes, options):
+    os.environ.pop('CCCP_CI_PROVISIONED', None)
+    os.environ.pop('CCCP_CI_HOSTS', None)
+
+    jenkins_master_host = nodes[0]
+    jenkins_slave_host = nodes[1]
+    openshift_host = nodes[2]
+    scanner_host = nodes[3]
+    controller = nodes.pop()
+
+    nodes_env = (
+        "\nJENKINS_MASTER_HOST=%s\n"
+        "JENKINS_SLAVE_HOST=%s\n"
+        "OPENSHIFT_HOST=%s\n"
+        "CONTROLLER=%s\n"
+        "SCANNER_HOST=%s\n"
+    ) % (jenkins_master_host, jenkins_slave_host,
+         openshift_host, controller, scanner_host)
+
+    with open('env.properties', 'a') as f:
+        f.write(nodes_env)
+
+    hosts_data = {
+        'openshift': {
+            'host': openshift_host,
+            'remote_user': 'root'
+        },
+        'jenkins_master': {
+            'host': jenkins_master_host,
+            'remote_user': 'root'
+        },
+        'jenkins_slave': {
+            'host': jenkins_slave_host,
+            'remote_user': 'root'
+        },
+        'controller': {
+            'host': controller,
+            'user': 'root',
+            'workdir': '/root/container-pipeline-service',
+            # relative to this workdir
+            'inventory_path': 'hosts'
+        }
+    }
+
+    _print(hosts_data)
+
+    generate_ansible_inventory(jenkins_master_host,
+                               jenkins_slave_host,
+                               openshift_host,
+                               scanner_host,
+                               options['nfs_share'])
+
+    run_cmd('iptables -F', host=openshift_host)
+    run_cmd('iptables -F', host=jenkins_slave_host)
+    run_cmd('setenforce 0', host=openshift_host)
+
+    setup_ssh_access(controller, nodes + [controller])
+    sync_controller(controller)
+    setup_controller(controller)
+
+    provision(hosts_data['controller'])
+
+    return {
+        'provisioned': True,
+        'hosts': hosts_data
+    }
+
+
+def test(data, path):
+    path = path or '~/container-pipeline-service/ci/tests'
+    hosts_env = json.dumps(data['hosts']).replace('"', '\\"')
+    provisioned_env = ('true' if data['provisioned'] else '')
+    controller = data['hosts']['controller']['host']
+    run_cmd(
+        'export CCCP_CI_HOSTS="%s" && '
+        'export CCCP_CI_PROVISIONED=%s && '
+        'nosetests %s' % (
+            hosts_env, provisioned_env, path),
+        host=controller, stream=True)
+
+
+def teardown():
+    pass

--- a/ci/tests/base.py
+++ b/ci/tests/base.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import json
 import unittest
 
@@ -46,7 +47,9 @@ class BaseTestCase(unittest.TestCase):
             force (bool): Provision forcefully.
             extra_args (str): Extra cmd line args for running ansible playbook
         """
-        provision(self.hosts['controller'], force=force, extra_args=extra_args)
+        controller = copy.copy(self.hosts['controller'])
+        controller['hosts'] = None
+        provision(controller, force=force, extra_args=extra_args)
 
     def run_cmd(self, cmd, user=None, host=None, stream=False):
         """

--- a/ci/tests/base.py
+++ b/ci/tests/base.py
@@ -3,7 +3,7 @@ import copy
 import json
 import unittest
 
-from ci.lib import provision, run_cmd
+from ci.lib import provision, run_cmd, _print
 
 
 class BaseTestCase(unittest.TestCase):
@@ -49,7 +49,11 @@ class BaseTestCase(unittest.TestCase):
         """
         controller = copy.copy(self.hosts['controller'])
         controller['hosts'] = None
-        provision(controller, force=force, extra_args=extra_args)
+        _print('Provisioning...')
+        provisioned, out = provision(
+            controller, force=force, extra_args=extra_args)
+        if provisioned:
+            _print(out[-1000:])
 
     def run_cmd(self, cmd, user=None, host=None, stream=False):
         """

--- a/ci/tests/test_00_openshift/__init__.py
+++ b/ci/tests/test_00_openshift/__init__.py
@@ -19,7 +19,6 @@ class TestOpenshift(BaseTestCase):
             "oc project 53b1a8ddd3df5d4fd94756e8c20ae160e565a4b339bfb47165285955 > /dev/null && "
             "oc get pods"
         ).format(openshift=self.hosts[self.node]['host'])
-        self.run_cmd(cmd)
         retries = 0
         success = False
         while retries < 10 and success is False:

--- a/ci/tests/test_01_index_ci/index_ci_base.py
+++ b/ci/tests/test_01_index_ci/index_ci_base.py
@@ -1,7 +1,6 @@
 from os import path
 
 from ci.tests.base import BaseTestCase
-from testindex.Engine import Engine
 
 config = {
     "test_index": "test_index",
@@ -42,4 +41,5 @@ class IndexCIBase(BaseTestCase):
     def _run_index_ci(self, msg, index_location):
         """Trigger an index ci run on remote machine and get the output for evaluation"""
         self._print_init_msg(msg)
+        from testindex.Engine import Engine
         return Engine(index_path=index_location, verbose=config["verbose"]).run()

--- a/ci/tests/test_01_index_ci/index_ci_base.py
+++ b/ci/tests/test_01_index_ci/index_ci_base.py
@@ -1,6 +1,5 @@
 from os import path
 
-from ci.lib import run_cmd
 from ci.tests.base import BaseTestCase
 from testindex.Engine import Engine
 
@@ -37,8 +36,8 @@ class IndexCIBase(BaseTestCase):
         if not config["local_run"]:
             self.setUp()
         elif config["local_setup"]:
-            run_cmd("sudo yum -y install epel-release", stream=True)
-            run_cmd("sudo yum -y install PyYAML python-networkx", stream=True)
+            self.run_cmd("sudo yum -y install epel-release", stream=True)
+            self.run_cmd("sudo yum -y install PyYAML python-networkx", stream=True)
 
     def _run_index_ci(self, msg, index_location):
         """Trigger an index ci run on remote machine and get the output for evaluation"""


### PR DESCRIPTION
This implements a script to speed up setup and testing on centos devcloud machines.

To use this, rsync container-pipeline-service source code to devcloud's jump host, and run ``python container-pipeline-service/ci/devcloud_ci.py -h`` for more info.
```
Usage:
# Setup
devcloud_ci.py setup <jenkins_master_vm_id> <jenkins_slave_vm_id> <openshift_vm_id> <scanner_host_vm_id> <controller_vm_id>

# test
devcloud_ci.py test

# teardown
devcloud_ci.py teardown
```