### PR TITLE
Fixes NFS server logs directory write permission config for CI

### DIFF
--- a/provisions/roles/ci_nfs/server/tasks/main.yml
+++ b/provisions/roles/ci_nfs/server/tasks/main.yml
@@ -27,7 +27,7 @@
   sudo: yes
   lineinfile:
     destfile: /etc/exports
-    line: "/nfsshare (rw,sync,no_root_squash)"
+    line: "/nfsshare (rw,sync,no_subtree_check,all_squash,anonuid=0,anongid=0)"
 
 - name: ensure iptables is configured to allow TCP ports 2049
   when: test


### PR DESCRIPTION
  Adds more option in NFS server /etc/exports config file to allow
  other (jenkins) user to write to NFS. This configuration is only
  applicable for dev environement and CI, for prod, it is configured
  separately. This replicates the prod config though.