### PR TITLE
Adds line number and process number for code logging

### DIFF
--- a/beanstalk_worker/config.py
+++ b/beanstalk_worker/config.py
@@ -10,7 +10,7 @@ LOGGING_CONF = dict(
     level=LOGLEVEL,
     formatters=dict(
         bare={
-            "format": '[%(asctime)s %(name)s %(levelname)s] %(message)s'
+            "format": '[%(asctime)s] %(name)s p%(process)s %(lineno)d %(levelname)s - %(message)s'
         },
     ),
     handlers=dict(

--- a/mail_service/config.py
+++ b/mail_service/config.py
@@ -10,7 +10,7 @@ LOGGING_CONF = dict(
     level=LOGLEVEL,
     formatters=dict(
         bare={
-            "format": '[%(asctime)s %(name)s %(levelname)s] %(message)s'
+            "format": '[%(asctime)s] %(name)s p%(process)s %(lineno)d %(levelname)s - %(message)s'
         },
     ),
     handlers=dict(


### PR DESCRIPTION
 This PR updates logging formatter config to include:
 pathname of the python script (earlier it was only name)
 process name
 line number in python script, string is logged from