### PR TITLE
Force pull fresh container images upon deployment

### DIFF
--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -111,6 +111,12 @@
       volumes:
         /srv/pipeline-logs:/srv/pipeline-logs:rw
 
+- name: Pull Linter image
+  docker_image:
+      name: registry.centos.org/pipeline-images/dockerfile-lint
+      state: present
+      force: yes
+
 - name: Copy Dockerfile linter worker
   copy:
       src: ../../beanstalk_worker/cccp-dockerfile-lint-worker.service

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -62,6 +62,7 @@
         - /etc/atomic.d/:/host/etc/atomic.d/
       command: sh /install.sh
       state: started
+      pull: yes
   tags: scanner
 
 - name: Install scanner-rpm-verify container
@@ -73,6 +74,7 @@
         - /etc/atomic.d/:/host/etc/atomic.d/
       command: sh /install.sh
       state: started
+      pull: yes
   tags: scanner
 
 - name: Install misc-package-updates container
@@ -84,7 +86,9 @@
         - /etc/atomic.d/:/host/etc/atomic.d/
       command: sh /install.sh
       state: started
+      pull: yes
   tags: scanner
+
 
 - name: Install misc-package-updates container
   docker_container:


### PR DESCRIPTION
Different approach for #149 since we still can't go with event based trigger approach as explained [here](https://github.com/CentOS/container-pipeline-service/pull/149#issuecomment-294446393).