### PR TITLE
Adds cccp_index_repo variable under all vars in hosts.sample

### DIFF
--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -22,10 +22,13 @@ public_registry=jenkins-slave
 beanstalk_server=openshift
 rsync_ssh_opts=""
 
+# update index repo URL per requirement
+cccp_index_repo=https://github.com/centos/container-index.git
+
 ## dev environment options, update following to configure NFS
 #test=True
 # replace scanner_worker below with its FQDN / IP
-#test_nfs_share= scanner_worker:/nfsshare
+#test_nfs_share=scanner_worker:/nfsshare
 
 [jenkins_master:vars]
 # update as needed


### PR DESCRIPTION
 Deployment failed complaining absense of cccp_index_repo variable.
 This was not the case earlier though.
 By adding the variable in all:vars section of hosts.sample file
 resolves the issue.
 This variable needs to be updated if doing testing deployment.
 The default value points to centos/container-index.gitt