### PR TITLE
Adds tags for all operations in ansible playbook

### DIFF
--- a/provisions/roles/ci/tasks/main.yml
+++ b/provisions/roles/ci/tasks/main.yml
@@ -4,3 +4,4 @@
   tags:
     - test
     - ci-build-test-project
+    - ci

--- a/provisions/roles/ci_nfs/clients/tasks/main.yml
+++ b/provisions/roles/ci_nfs/clients/tasks/main.yml
@@ -3,6 +3,9 @@
   when: setup_nfs
   sudo: yes
   yum: name=nfs-utils state=present
+  tags:
+  - ci_nfs
+  - test
 
 - name: Create NFS mount directory
   when: setup_nfs
@@ -11,6 +14,9 @@
     path: /srv/pipeline-logs
     state: directory
     mode: 0777
+  tags:
+  - ci_nfs
+  - test
 
 - name: Mount NFS share on the node
   when: setup_nfs
@@ -20,3 +26,6 @@
     src: "{{ test_nfs_share }}"
     fstype: nfs
     state: mounted
+  tags:
+  - ci_nfs
+  - test

--- a/provisions/roles/ci_nfs/server/tasks/main.yml
+++ b/provisions/roles/ci_nfs/server/tasks/main.yml
@@ -3,16 +3,25 @@
   when: setup_nfs
   sudo: yes
   yum: name=nfs-utils state=present
+  tags:
+  - ci_nfs
+  - test
 
 - name: Install firewalld for opening NFS ports
   when: setup_nfs
   sudo: yes
   yum: name=firewalld state=present
+  tags:
+  - ci_nfs
+  - test
 
 - name: Start firewalld service
   when: setup_nfs
   sudo: yes
   service: name=firewalld enabled=yes state=started
+  tags:
+  - ci_nfs
+  - test
 
 - name: Create NFS mount directory
   when: setup_nfs
@@ -21,6 +30,9 @@
     path: /nfsshare
     state: directory
     mode: 0777
+  tags:
+  - ci_nfs
+  - test
 
 - name: Add entry in /etc/exports to configure NFS mount
   when: setup_nfs
@@ -28,18 +40,30 @@
   lineinfile:
     destfile: /etc/exports
     line: "/nfsshare (rw,sync,no_subtree_check,all_squash,anonuid=0,anongid=0)"
+  tags:
+  - ci_nfs
+  - test
 
 - name: ensure iptables is configured to allow TCP ports 2049
   when: setup_nfs
   sudo: yes
   firewalld: port=2049/tcp zone=public permanent=true state=enabled immediate=yes
+  tags:
+  - ci_nfs
+  - test
 
 - name: Ensure iptables is configured to allow TCP ports 111
   when: setup_nfs
   sudo: yes
   firewalld: port=111/tcp zone=public permanent=true state=enabled immediate=yes
+  tags:
+  - ci_nfs
+  - test
 
 - name: Start and Enable NFS service
   when: setup_nfs
   sudo: yes
   service: name=nfs-server enabled=yes state=started
+  tags:
+  - ci_nfs
+  - test

--- a/provisions/roles/jenkins/master/tasks/main.yml
+++ b/provisions/roles/jenkins/master/tasks/main.yml
@@ -1,10 +1,16 @@
 - include: install.yml
+  tags:
+  - jenkins/master
 
 - include: config.yml
+  tags:
+  - jenkins/master
 
 - name: Restart jenkins
   service: name=jenkins state=restarted
   sudo: yes
+  tags:
+  - jenkins/master
 
 - name: Wait for Jenkins to come up
   shell: curl --head --silent http://localhost:8080/cli/
@@ -12,11 +18,17 @@
   until: result.stdout.find("200 OK") != -1
   retries: 50
   delay: 10
+  tags:
+    - jenkins/master
 
 - include: plugins.yml
+  tags:
+    - jenkins/master
 
 - name: restart jenkins
   service: name=jenkins state=restarted enabled=yes
+  tags:
+    - jenkins/master
 
 - name: Wait for Jenkins to come up
   shell: curl --head --silent http://localhost:8080/cli/
@@ -24,20 +36,25 @@
   until: result.stdout.find("200 OK") != -1
   retries: 50
   delay: 10
+  tags:
+    - jenkins/master
 
 - include: jobs.yml
   tags:
     - jenkins
     - jobs
+    - jenkins/master
 
 - name: Copy script to monitor access to Jenkins slave from master using Zabbix
   template: src=cron_check_slave_uptime.sh.j2 dest=/root/cron_check_slave_uptime.sh mode=0755
   tags:
     - jenkins
     - monitor
+    - jenkins/master
 
 - name: Cronjob to check if Jenkins slave is up, every minute
   cron: name="check jenkins slave access" job="/root/cron_check_slave_uptime.sh"
   tags:
     - jenkins
     - monitor
+    - jenkins/master

--- a/provisions/roles/jenkins/slave/tasks/main.yml
+++ b/provisions/roles/jenkins/slave/tasks/main.yml
@@ -2,35 +2,38 @@
 - name: create jenkins user
   user: name=jenkins state=present createhome=yes system=no
   tags:
-  - jenkins
-  - jenkins/slave
-  - config
+    - jenkins
+    - jenkins/slave
+    - config
 
 - name: add jenkins ssh public key to authorized keys
   authorized_key: user=jenkins key="{{ item }}"
   with_file:
   - "{{ jenkins_public_key_file }}"
   tags:
-  - jenkins
-  - jenkins/slave
-  - config
+    - jenkins
+    - jenkins/slave
+    - config
 
 - name: create workspace directory
   file: state=directory path=/srv/jenkins owner=jenkins group=jenkins
   tags:
-  - jenkins
-  - jenkins/slave
-  - config
+    - jenkins
+    - jenkins/slave
+    - config
 
 - include: setup_oc.yml
   tags:
-  - openshift/jenkins
+    - openshift/jenkins
+    - jenkins/slave
 
 - include: setup_worker.yml
   tags:
-  - beanstalk/worker
+    - beanstalk/worker
+    - jenkins/slave
 
 - include: monitor.yml
   tags:
-      - jenkins
-      - monitor
+    - jenkins
+    - monitor
+    - jenkins/slave

--- a/provisions/roles/nginx/tasks/main.yml
+++ b/provisions/roles/nginx/tasks/main.yml
@@ -3,12 +3,16 @@
     sudo: yes
     yum: name=epel-release state=present
     when: enable_epel
+    tags:
+      - nginx
+      - jenkins/slave
 
   - name: Install nginx
     sudo: yes
     yum: name=nginx state=present
     tags:
       - nginx
+      - jenkins/slave
 
   - name: Copy SSL certs
     sudo: yes
@@ -17,17 +21,22 @@
         - { src: "{{ ssl_key_template }}", dest: "{{ ssl_key_file }}" }
         - { src: "{{ ssl_cert_template }}", dest: "{{ ssl_cert_file }}" }
     when: copy_ssl_certs
-    tags: nginx
+    tags:
+      - nginx
+      - jenkins/slave
+
 
   - name: Copy nginx conf for CentOS registry
     sudo: yes
     template: src={{ nginx_conf_template }} dest=/etc/nginx/conf.d/{{ nginx_conf_filename }}
     tags:
       - nginx
+      - jenkins/slave
 
   - name: restart nginx
     sudo: yes
     service: name=nginx state=restarted enabled=yes
     tags:
       - nginx
+      - jenkins/slave
 

--- a/provisions/roles/openshift/tasks/main.yml
+++ b/provisions/roles/openshift/tasks/main.yml
@@ -1,12 +1,22 @@
 ---
 - include: install.yml
+  tags:
+    - openshift
 
 - include: config.yml
+  tags:
+    - openshift
 
 - include: setup.yml
+  tags:
+    - openshift
 
 - include: fetch.yml
   tags:
     - openshift/jenkins
+    - openshift
 
 - include: setup_mailservice.yml
+  tags:
+    - openshift
+    - mail_service

--- a/provisions/roles/openshift/tasks/setup.yml
+++ b/provisions/roles/openshift/tasks/setup.yml
@@ -23,7 +23,7 @@
 - name: Wait for Openshift Router to come up
   pause: seconds={{ openshift_startup_delay }}
 
-- name: Create test user 
+- name: Create test user
   command: "{{ item }}"
   with_items:
     - "oadm policy add-role-to-user view test-admin --config={{ kubeconfig }}"

--- a/provisions/roles/registry/tasks/main.yml
+++ b/provisions/roles/registry/tasks/main.yml
@@ -2,7 +2,13 @@
 - name: Install Docker distribution
   yum: name=docker-distribution state=present
   sudo: yes
+  tags:
+    - registry
+    - jenkins/slave
 
 - name: Enable and run Docker Distribution
   service: name=docker-distribution enabled=yes state=started
   sudo: yes
+  tags:
+    - registry
+    - jenkins/slave

--- a/provisions/roles/repo_tracking/tasks/main.yml
+++ b/provisions/roles/repo_tracking/tasks/main.yml
@@ -2,36 +2,44 @@
 - name: Enable epel
   yum: name=epel-release state=installed
   sudo: yes
+  tags: repo_tracking
 
 - name: Install Django
   yum: name=Django state=installed
   sudo: yes
+  tags: repo_tracking
 
 - name: Install Docker
   yum: name=docker state=installed
   sudo: yes
+  tags: repo_tracking
 
 - name: Install docker-py
   yum: name=python-docker-py state=installed
   sudo: yes
+  tags: repo_tracking
 
 - name: Install python-psycopg2
   yum: name=python-psycopg2 state=installed
   sudo: yes
+  tags: repo_tracking
 
 - name: Ensure docker group exists
   group: name=docker state=present
   sudo: yes
+  tags: repo_tracking
 
 - name: Ensure that user jenkins is included in docker group
   user: name=jenkins groups=docker append=yes
   sudo: yes
+  tags: repo_tracking
 
 - name: Enable Docker Registry
   replace: >
     dest=/etc/sysconfig/docker
     regexp="^#*\s*ADD_REGISTRY=.*"
     replace='ADD_REGISTRY="--add-registry {{ public_registry }}:5000 --insecure-registry {{ public_registry }}:5000"'
+  tags: repo_tracking
 
 - name: Enable access to Docker daemon over TCP in localhost
   replace: >
@@ -43,6 +51,7 @@
 - name: Enable and start Docker service
   service: name=docker state=started
   sudo: yes
+  tags: repo_tracking
 
 - name: Install fedmsg and utils
   yum: name={{ item }} state=installed
@@ -50,6 +59,7 @@
   with_items:
     - fedmsg
     - fedmsg-relay
+  tags: repo_tracking
 
 - name: Don't validate fedmsg signatures
   replace:
@@ -57,6 +67,7 @@
       regexp: "validate_signatures=True"
       replace: "validate_signatures=False"
   sudo: yes
+  tags: repo_tracking
 
 - name: Sync repo tracking code
   synchronize:
@@ -69,14 +80,17 @@
     - src
     - jenkinsbuilder
   sudo: yes
+  tags: repo_tracking
 
 - name: Customize settings
   template: src=settings.py.j2 dest=/opt/cccp-service/src/container_pipeline/settings.py owner=jenkins
   sudo: yes
+  tags: repo_tracking
 
 - name: Ensure cccp data dir exists
   file: path=/var/lib/cccp/db state=directory
   sudo: yes
+  tags: repo_tracking
 
 - name: Set selinux context for datadir for mounting in containers
   sefcontext:
@@ -84,12 +98,14 @@
       setype: svirt_sandbox_file_t
       state: present
   sudo: yes
+  tags: repo_tracking
 
 - name: Pull CentOS postgres container
   docker_image:
       name: docker.io/centos/postgresql-95-centos7
       tag: latest
   sudo: yes
+  tags: repo_tracking
 
 - name: Run postgres container
   docker_container:
@@ -106,44 +122,53 @@
       state: started
       restart_policy: on-failure
   sudo: yes
+  tags: repo_tracking
 
 - name: Wait for 10 seconds for the db to come up
   pause:
       seconds: 10
+  tags: repo_tracking
 
 - name: Create DB tables
   shell: /opt/cccp-service/src/manage.py syncdb --noinput
   sudo: yes
+  tags: repo_tracking
 
 - name: Copy fedmsg conf
   copy:
       src: "{{ role_path }}/../../../fedmsg.d/container_pipeline.py"
       dest: "/etc/fedmsg.d/container_pipeline.py"
   sudo: yes
+  tags: repo_tracking
 
 - name: Copy empty fedmsg endpoints conf
   copy:
       src: fedmsg_endpoints.py
       dest: /etc/fedmsg.d/endpoints.py
   sudo: yes
+  tags: repo_tracking
 
 - name: Start fedmsg-relay
   service: name=fedmsg-relay state=restarted enabled=True
   sudo: yes
+  tags: repo_tracking
 
 - name: Get container index
   git:
     repo: https://github.com/rtnpro/container-index
     dest: /opt/container-index
   sudo: yes
+  tags: repo_tracking
 
 - name: Ensure jenkins user can write to log file
   file: path=/srv/pipeline-logs/cccp.log state=file owner=jenkins
   sudo: yes
+  tags: repo_tracking
 
 - name: Copy jenkins job template
   template: src=jobs.yml.j2 dest="{{ ansible_env.HOME }}/repo_tracking_job.yml"
   sudo: yes
+  tags: repo_tracking
 
 - name: Ensure jenkins user is owner of src dir
   file:
@@ -151,9 +176,11 @@
       owner: jenkins
       recurse: yes
   sudo: yes
+  tags: repo_tracking
 
 - name: Create jenkins jobs
   shell: "jenkins-jobs --ignore-cache update {{ ansible_env.HOME }}/repo_tracking_job.yml"
+  tags: repo_tracking
 
 - name: Copy servie files
   copy: src="{{ role_path }}/../../../src/scripts/{{ item }}" dest=/etc/systemd/system/ mode=u+x
@@ -162,6 +189,7 @@
       - cccp_triggerbuilds.service
       - cccp_imagescanner.service
   sudo: yes
+  tags: repo_tracking
 
 - name: Enable and start services
   service: name={{ item }} state=restarted enabled=yes
@@ -170,3 +198,4 @@
       - cccp_triggerbuilds
       - cccp_imagescanner
   sudo: yes
+  tags: repo_tracking

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -2,11 +2,13 @@
 - name: Install Atomic
   yum: name=atomic state=present
   sudo: yes
+  tags: scanner
 
 # Fix for issue:  https://github.com/projectatomic/atomic/issues/804
 - name: Install python-dateutil
   yum: name=python-dateutil state=present
   sudo: yes
+  tags: scanner
 
 # Patch from https://github.com/projectatomic/atomic/commit/a261270e727353899675a3fde8f9108376bb27cf
 - name: Patch atomic scanner to run on non tty input
@@ -15,34 +17,41 @@
       regexp="'-it'"
       replace="'-t'"
   sudo: yes
+  tags: scanner
 
 - name: Install docker
   yum: name=docker state=present
   sudo: yes
+  tags: scanner
 
 - name: Start and Enable docker
   service: name=docker enabled=yes state=started
   sudo: yes
+  tags: scanner
 
 - name: Enable Docker Host socket
   replace: >
     dest=/etc/sysconfig/docker
     regexp="^#*\s*OPTIONS=.*"
     replace='OPTIONS="--selinux-enabled --log-driver=journald -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock"'
+  tags: scanner
 
 - name: Enable Docker Registry
   replace: >
     dest=/etc/sysconfig/docker
     regexp="^#*\s*ADD_REGISTRY=.*"
     replace='ADD_REGISTRY="--add-registry {{ public_registry }} --insecure-registry {{ public_registry }}:5000"'
+  tags: scanner
 
 - name: Set SELinux to permissive
   selinux:
       policy: targeted
       state: permissive
+  tags: scanner
 
 - name: Restart Docker
   service: name=docker state=restarted enabled=yes
+  tags: scanner
 
 - name: Install pipeline-scanner container
   docker_container:
@@ -53,6 +62,7 @@
         - /etc/atomic.d/:/host/etc/atomic.d/
       command: sh /install.sh
       state: started
+  tags: scanner
 
 - name: Install scanner-rpm-verify container
   docker_container:
@@ -63,6 +73,7 @@
         - /etc/atomic.d/:/host/etc/atomic.d/
       command: sh /install.sh
       state: started
+  tags: scanner
 
 - name: Install misc-package-updates container
   docker_container:
@@ -73,9 +84,11 @@
         - /etc/atomic.d/:/host/etc/atomic.d/
       command: sh /install.sh
       state: started
+  tags: scanner
 
 - name: Ensure /opt/cccp-service/beanstalk_worker dir exists on Jenkins slaves
   file: dest=/opt/cccp-service/beanstalk_worker state=directory
+  tags: scanner
 
 - name: Get scanner worker scripts
   copy:
@@ -89,6 +102,7 @@
     - ../beanstalk_worker/constants.py
     - ../beanstalk_worker/scanner.py
   when: not vagrant
+  tags: scanner
 
 - name: Get service files for workers
   copy:
@@ -96,18 +110,23 @@
     dest: "{{ item.dest }}"
   with_items:
       - {src: "../beanstalk_worker/cccp-scan-worker.service", dest: /etc/systemd/system/cccp-scan-worker.service}
+  tags: scanner
 
 - name: Ensure log path exists
   file: path=/srv/pipeline-logs/cccp.log state=touch
+  tags: scanner
 
 - name: Enable Scanner worker
   service: name="cccp-scan-worker" state=restarted enabled=yes
+  tags: scanner
 
 - name: Replace Beanstalk server with its FQDN for test worker
   replace: >
       dest=/opt/cccp-service/beanstalk_worker/worker_start_scan.py
       regexp="BEANSTALK_SERVER"
       replace='{{ groups['openshift'][0] }}'
+  tags: scanner
 
 - name: Enable Scanner worker
   service: name="cccp-scan-worker" state=restarted enabled=yes
+  tags: scanner


### PR DESCRIPTION
 This PR aims to add tags in all the operations of ansible playbook.
 The reason for doing this is to have more control over deployment,
 in a way to run operations only on particular node.

 A subset of operations in existing playbook have tags, but this PR
 tags all the operations.

 How this will be useful: For example if deployment failed for some reason
 just before configuring scanner node, one can resume the installation by
 specifying scan tag while re-running the deployment.