### PR TITLE
Re applying changes from 'Bugfix in populating image data post delivery'

### DIFF
--- a/server/run-test.sh
+++ b/server/run-test.sh
@@ -45,7 +45,7 @@ _ "Pushing the image to registry (${OUTPUT_IMAGE})"
 #fi
 docker push ${FULL_TO}||jumpto sendstatusmail
 
-python /tube_request/send_scan_request.py ${BEANSTALK_SERVER} ${NS} ${OUTPUT_IMAGE} ${TEST_TAG} ${NOTIFY_EMAIL} ${LOGS_DIR} ${JOBID}
+python /tube_request/send_scan_request.py ${BEANSTALK_SERVER} ${NS} ${OUTPUT_IMAGE} ${TEST_TAG} ${NOTIFY_EMAIL} ${LOGS_DIR} ${JOBID} ${IMAGE_NAME}
 
 _ "Cleaning environment"
 docker rmi ${FULL_FROM}

--- a/server/send_scan_request.py
+++ b/server/send_scan_request.py
@@ -14,6 +14,7 @@ image_details["TEST_TAG"] = sys.argv[4]
 image_details["notify_email"] = sys.argv[5]
 image_details["logs_dir"] = sys.argv[6]
 image_details["job_name"] = sys.argv[7]
+image_details["image_name"] = sys.argv[8]
 print "Pushing image details in the tube"
 bs = beanstalkc.Connection(host=beanstalk_host)
 bs.use("master_tube")


### PR DESCRIPTION
changes from https://github.com/CentOS/container-pipeline-service/commit/523ac14ea196ab356a56b6815c801ef0e6a05c5a
had been wiped out by https://github.com/CentOS/container-pipeline-service/commit/225ea72aa0d9c4f9381de2e2434a5fee1ade06ac