### PR TITLE
Uncomment NFS configuration flag in hosts.sample

### DIFF
--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -26,7 +26,7 @@ rsync_ssh_opts=""
 cccp_index_repo=https://github.com/centos/container-index.git
 
 ## dev environment options, update following to true to configure NFS
-#setup_nfs=False
+setup_nfs=False
 # replace scanner_worker below with its FQDN / IP
 #test_nfs_share=scanner_worker:/nfsshare
 


### PR DESCRIPTION
 we added a new line

	#setup_nfs=False

 this option needs to be updated every time a deployment
 is happening. Plus it has two valid options. For production,
 we need to make it False and True for dev environment.
 So, why to make it commented out ? If wee keep defaults
 for production, still it can be set to False (which it is)
 but without commented line.