### PR TITLE
Filters paths with known issues in rpm-verify scanner results

### DIFF
--- a/atomic_scanners/scanner-rpm-verify/rpm_verify_constants.py
+++ b/atomic_scanners/scanner-rpm-verify/rpm_verify_constants.py
@@ -1,0 +1,23 @@
+"""
+This is a constants file for rpm-verify atomic scanner
+In this file, one can mention the files to be excluded in end
+result of scanner OR Any other expected property configuration
+changes
+"""
+
+
+# Filter the paths you know the resulting image or base image itself
+# has issue about and need to be filtered
+# out since this is a known issue and it is in progress to get fixed.
+FILTER_PATHS = [
+  "/",   # centos base image has issue with this filepath
+]
+
+
+# Filter filepaths starting with following directories listing,
+# since these paths are expected to be modified and should not
+# take into account
+
+FILTER_DIRS = [
+    "/var", "/run", "/media", "/mnt", "/tmp", "/proc", "/sys", "/boot"
+]


### PR DESCRIPTION
  RPM verify is reporting issue in centos base image itself with
  filepath `/` shown as file attributes modification.
  All the layers built on top of centos base image is reporting same
  issue when scanner is ran on resulting image. The results are being
  sent to service users, and to avoid confusion we should filter this
  result from end result and get it fixed in base image. Once the issue
  is fixed in base image, we can update the scanner config to revert the
  change.