### PR TITLE
Fixes project name processing in subject for failed builds

### DIFF
--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -110,12 +110,8 @@ class NotifyUser(object):
         else:
             logger.debug("Processing mail for failed build.")
             self.image_under_test = job_info.get("project_name")
-            # for eg here
-            # self.image_under_test = nshaikh-scanner-rpm-verify-latest
-            # we want to make nshaikh/scanner-rpm-verify:latest
-            names = self.image_under_test.split("-")
-            self.project = names[0] + "/" + "-".join(names[1:-1]) +\
-                ":" + names[-1]
+            # projet_name / self.image_under_test and self.project are same
+            self.project = job_info.get("project_name")
 
         # build_logs filename
         self.build_logs = urljoin(


### PR DESCRIPTION
  The processing for project name for failed builds had a bug.

  For project with;
    aap-id: kbsingh
    job-id: golang
    desired-tag: 1.7.4-1.el7

  The logic was failing whe tried to split by hyphen ("-"),
  the erroneous name was kbsingh/golang:1.7.4/:1.el7

  Fixed the name in this changeset.