### PR TITLE
Handle beanstalk socket errors in long running scripts

### DIFF
--- a/beanstalk_worker/worker_dispatcher.py
+++ b/beanstalk_worker/worker_dispatcher.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sys
 
 
 import beanstalkc
@@ -10,49 +11,62 @@ import config
 
 config.load_logger()
 logger = logging.getLogger("dispatcher")
+beanstalkd_host = "BEANSTALK_SERVER"
 
-bs = beanstalkc.Connection(host="BEANSTALK_SERVER")
-bs.watch("master_tube")
 
-logger.info("Starting dispatcher")
+def main():
+    try:
+        bs = beanstalkc.Connection(host=beanstalkd_host)
+        bs.watch("master_tube")
 
-while True:
-    job = bs.reserve()
-    job_details = json.loads(job.body)
-    logger.info('Got job: %s' % job_details)
+        logger.info("Starting dispatcher")
 
-    logger.info("Retrieving job action")
-    action = str(job_details['action'])
+        while True:
+            job = bs.reserve()
+            job_details = json.loads(job.body)
+            logger.info('Got job: %s' % job_details)
 
-    if action == "start_build":
-        bs.use("start_build")
-        bs.put(json.dumps(job_details))
-        logger.info("Job moved to build tube")
+            logger.info("Retrieving job action")
+            action = str(job_details['action'])
 
-    elif action == "start_scan":
-        bs.use("start_scan")
-        bs.put(json.dumps(job_details))
-        logger.info("Job moved to test tube")
+            if action == "start_build":
+                bs.use("start_build")
+                bs.put(json.dumps(job_details))
+                logger.info("Job moved to build tube")
 
-    elif action == "start_delivery":
-        bs.use("start_delivery")
-        bs.put(json.dumps(job_details))
-        logger.info("Job moved to delivery tube")
+            elif action == "start_scan":
+                bs.use("start_scan")
+                bs.put(json.dumps(job_details))
+                logger.info("Job moved to test tube")
 
-    elif action == "notify_user":
-        bs.use("notify_user")
-        bs.put(json.dumps(job_details))
-        logger.info("Job moved to notify tube")
+            elif action == "start_delivery":
+                bs.use("start_delivery")
+                bs.put(json.dumps(job_details))
+                logger.info("Job moved to delivery tube")
 
-    elif action == "report_scan_results":
-        bs.use("report_scan_results")
-        bs.put(json.dumps(job_details))
-        logger.info("Job moved to report scan results tube")
+            elif action == "notify_user":
+                bs.use("notify_user")
+                bs.put(json.dumps(job_details))
+                logger.info("Job moved to notify tube")
 
-    elif action == "start_linter":
-        bs.use("start_linter")
-        bs.put(json.dumps(job_details))
-        logger.info("Job moved to linter tube")
+            elif action == "report_scan_results":
+                bs.use("report_scan_results")
+                bs.put(json.dumps(job_details))
+                logger.info("Job moved to report scan results tube")
 
-    logger.debug("Deleting job: %s" % job_details)
-    job.delete()
+            elif action == "start_linter":
+                bs.use("start_linter")
+                bs.put(json.dumps(job_details))
+                logger.info("Job moved to linter tube")
+
+            logger.debug("Deleting job: %s" % job_details)
+            job.delete()
+    except beanstalkc.SocketError:
+        logger.critical(
+            'Unable to communicate to beanstalk server: %s. Exiting...'
+            % beanstalkd_host
+        )
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -8,6 +8,8 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
+
 import config
 
 from Atomic import Atomic, mount
@@ -552,8 +554,14 @@ class ContainerCapabilities(Scanner):
 
         return data
 
-
-bs = beanstalkc.Connection(host=BEANSTALKD_HOST)
+try:
+    bs = beanstalkc.Connection(host=BEANSTALKD_HOST)
+except beanstalkc.SocketError:
+    logger.critical(
+        'Unable to communicate to beanstalk server: %s. Exiting...'
+        % BEANSTALKD_HOST
+    )
+    sys.exit(1)
 bs.watch("start_scan")
 
 
@@ -591,6 +599,12 @@ while True:
             logger.info(
                 "Put job for delivery on master tube with id = %s" % job_id
             )
+    except beanstalkc.SocketError:
+        logger.critical(
+            'Unable to communicate to beanstalk server: %s. Exiting...'
+            % BEANSTALKD_HOST
+        )
+        sys.exit(1)
     except Exception as e:
         logger.fatal(str(e), exc_info=True)
         job_info["action"] = "start_delivery"

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 
 from urlparse import urljoin
 # FIXME: we've duplicated config.py from ../beanstalk_worker into this dir
@@ -14,8 +15,13 @@ from config import load_logger
 
 load_logger()
 logger = logging.getLogger('mail-service')
+beanstalkd_host = '127.0.0.1'
 
-bs = beanstalkc.Connection(host="172.17.0.1")
+try:
+    bs = beanstalkc.Connection(host=beanstalkd_host)
+except beanstalkc.SocketError:
+    logger.critical('Unable to connect to beanstalkd server: %s. Exiting...'
+                    % beanstalkd_host)
 bs.watch("notify_user")
 
 LOGS_DIR_PARENT = "/srv/pipeline-logs/"
@@ -317,12 +323,19 @@ class NotifyUser(object):
 
 
 while True:
-    logger.debug("Listening to notify_user tube")
-    job = bs.reserve()
-    job_id = job.jid
-    job_info = json.loads(job.body)
-    logger.info("Received Job:")
-    logger.debug(str(job_info))
-    notify_user = NotifyUser(job_info)
-    notify_user.notify_user()
-    job.delete()
+    try:
+        logger.debug("Listening to notify_user tube")
+        job = bs.reserve()
+        job_id = job.jid
+        job_info = json.loads(job.body)
+        logger.info("Received Job:")
+        logger.debug(str(job_info))
+        notify_user = NotifyUser(job_info)
+        notify_user.notify_user()
+        job.delete()
+    except beanstalkc.SocketError:
+        logger.critical(
+            'Unable to communicate to beanstalk server: %s. Exiting...'
+            % beanstalkd_host
+        )
+        sys.exit(1)


### PR DESCRIPTION
This is an attempt to handle beanstalk connection errors in our long running scripts. We need this, because, currently on beanstalk connection errors, our services flood the log file with beanstalk connection error logs.

I have 2 solutions in mind for it's solution:

1. Log beanstalk error as critical and error out, and let ``systemd`` or ``docker`` restart the application with some delay, say **10 seconds**.
     **Pros**
     - Simple code in our services

    **Cons**
     - Docker, unlike systemd, does not support restart with delay

1. Handle beanstalk errors in our script, log it, and re create beanstalk connection with some delay.

    **Pros**
    - Will work with Docker

    **Cons**
    - Will lead to more code complexity

Currently, the pull request have implemented solution ``1``, and then I discovered that docker does not support restart with delay. A possible workaround could be running docker containers using systemd service files, which will need a little bit of work, but it seems cleaner.

However, I am not sure of what's the best method, so, I 'd like to hear your opinions on this.