### PR TITLE
Remove duplicacy in TEST_TAG and do not add host info in scanner logs

### DIFF
--- a/atomic_scanners/container-capabilities-scanner/scanner.py
+++ b/atomic_scanners/container-capabilities-scanner/scanner.py
@@ -53,7 +53,7 @@ def check_image_for_run_label(image):
     run_label = run_object.get_label("RUN")
 
     if run_label == "":
-        raise RunLabelException("{} doesn't have a RUN label".format(image))
+        raise RunLabelException("Image doesn't have a RUN label")
     return run_label
 
 

--- a/jenkinsbuilder/project-defaults.yml
+++ b/jenkinsbuilder/project-defaults.yml
@@ -17,7 +17,7 @@
     builders:
         - shell: |
             export DOCKERFILE_DIR=`pwd`
-            TEST_TAG=`date | md5sum | base64 | head -c 14`
+            TEST_TAG=`date +%s%N | md5sum | base64 | head -c 14`
             LOGS_DIR=/srv/pipeline-logs/$TEST_TAG
             echo "Creating logs directory $LOGS_DIR"
             mkdir $LOGS_DIR

--- a/jenkinsbuilder/weekly-scan.py
+++ b/jenkinsbuilder/weekly-scan.py
@@ -60,7 +60,7 @@ for f in files:
 
         # TEST_TAG generation, unique per project
         task = subprocess.Popen(
-            "date | md5sum | base64 | head -c 14",
+            "date +%s%N | md5sum | base64 | head -c 14",
             shell=True,
             stdout=subprocess.PIPE)
         TEST_TAG = task.stdout.read()


### PR DESCRIPTION
As a part of #259 this PR fixes two items:

- `TEST_TAG` creation which uses `date` command's output is now accurate up to nanoseconds instead of a second. This is to ensure unique `TEST_TAG`s get created for weekly scan jobs. As a part of keeping things consistent, modified the same for all jobs through `projectdefaults.yml`

- Image name which also contains the host info is removed from container-capabilities-scanner's results since the email we send to developer already has that info in correct form.