### PR TITLE
Issue 264 - Fix logging for image pull failure

### DIFF
--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -70,7 +70,9 @@ class ScannerRunner(object):
         )
 
         if 'error' in pull_data:
-            logger.fatal("Couldn't pull requested image", extra=pull_data)
+            logger.fatal("Error pulling requested image {}: {}".format(
+                image_under_test, pull_data
+            ))
             return False
         logger.info("Image is pulled %s" % image_under_test)
         return True


### PR DESCRIPTION
Before the fix:
```python
[2017-05-15 07:59:36,586] scan-worker p20558 146 INFO - Image under test:dev-32-142.lon1.centos.org:5000/simple
[2017-05-15 07:59:36,586] scan-worker p20558 67 INFO - Pulling image dev-32-142.lon1.centos.org:5000/simple
[2017-05-15 07:59:36,633] scan-worker p20558 595 CRITICAL - string indices must be integers
Traceback (most recent call last):
  File "worker_start_scan.py", line 566, in <module>
    status, scanners_data = scan_runner_obj.run()
  File "worker_start_scan.py", line 155, in run
    if not self.pull_image_under_test(image_under_test):
  File "worker_start_scan.py", line 73, in pull_image_under_test
    logger.fatal("Couldn't pull requested image", extra=pull_data)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1194, in critical
    self._log(CRITICAL, msg, args, **kwargs)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1267, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args, exc_info, func, extra)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1246, in makeRecord
    rv.__dict__[key] = extra[key]
TypeError: string indices must be integers
[2017-05-15 07:59:36,741] scan-worker p20558 600 INFO - Job moved from scan phase.
```

After the fix

```python
[2017-05-15 07:54:48,713] scan-worker p1182 148 INFO - Image under test:dev-32-142.lon1.centos.org:5000/simple
[2017-05-15 07:54:48,713] scan-worker p1182 67 INFO - Pulling image dev-32-142.lon1.centos.org:5000/simple
[2017-05-15 07:54:48,732] scan-worker p1182 74 CRITICAL - Error pulling requested image dev-32-142.lon1.centos.org:5000/simple: {"status":"Trying to pull repository dev-32-142.lon1.centos.org:5000/simple ... "}
{"errorDetail":{"message":"name unknown: repository name not known to registry"},"error":"name unknown: repository name not known to registry"}

[2017-05-15 07:54:48,732] scan-worker p1182 158 INFO - Image pulled failed, moving job to delivery phase.
[2017-05-15 07:54:48,732] scan-worker p1182 571 CRITICAL - Failed to run scanners on image under test, moving on!
[2017-05-15 07:54:48,733] scan-worker p1182 602 INFO - Job moved from scan phase.
```