### PR TITLE
Escapes tabs for email rendering in mail server

### DIFF
--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -121,9 +121,9 @@ class NotifyUser(object):
         )
 
     def _escape_text_(self, text):
-        "Escapes \n with \\n for rendering newlines in email body"
+        "Escapes \n,\t with \\n,\\tt for rendering in email body"
 
-        return text.replace("\n", "\\n")
+        return text.replace("\n", "\\n").replace("\t", "\\t")
 
     def update_subject_of_email(self, subject):
         """
@@ -148,7 +148,6 @@ class NotifyUser(object):
 
             # alter subject
             return "[test] " + subject
-
 
     def send_email(self, subject, contents):
         "Sends email to user"


### PR DESCRIPTION
  This changeset escapes tabs (`\t`) while generating contents
  for email. New lines escaping is in place, but tabs escaping
  was not done.