### PR TITLE
Verbose description of scanner-rpm-verify result

### DIFF
--- a/atomic_scanners/scanner-rpm-verify/rpm_verify.py
+++ b/atomic_scanners/scanner-rpm-verify/rpm_verify.py
@@ -181,6 +181,8 @@ class RPMVerify(object):
         # Also we should log the RPMs failing the rpm -V test
         # print "Issue found while running rpm -Va test: "
         # print error
+        if not result:
+            result = ["No issues. Libraries and Binaries are intact."]
         return {"rpmVa_issues": result}
 
     def export_results(self, data):


### PR DESCRIPTION
  If image does not have any rpm validation issue, result
  of scanner states that explicitly. Earlier if there were no issues
  resulted by `rpm -Va`, it will result an empty list.