### PR TITLE
Updated index ci to fail on appid-filename mismatch.

### DIFF
--- a/ci/tests/test_01_index_ci/test_02_index_values/__init__.py
+++ b/ci/tests/test_01_index_ci/test_02_index_values/__init__.py
@@ -9,8 +9,8 @@ class TestIndexValues(IndexCIBase):
                                             self._test_index_location + "test_00")[0])
         print("VERIFIED")
 
-    def test_01_succeeds_app_id_mismatch(self):
-        self.assertTrue(self._run_index_ci("Test if index ci succeeds if app-id mismatches with file name",
+    def test_01_fails_app_id_mismatch(self):
+        self.assertFalse(self._run_index_ci("Test if index ci fails if app-id mismatches with file name",
                                             self._test_index_location + "test_01")[0])
         print("VERIFIED")
 

--- a/testindex/validators.py
+++ b/testindex/validators.py
@@ -128,7 +128,8 @@ class IndexFormatValidator(IndexValidator):
 
             else:
                 if entry["app-id"] != self._file_name.split(".")[0]:
-                        self._summary_collector.add_warning("app-id should be same as first part of the file name")
+                    self._mark_entry_invalid(entry)
+                    self._summary_collector.add_error("app-id should be same as first part of the file name")
 
                 if "_" in entry["app-id"] or "/" in entry["app-id"] or "." in entry["app-id"]:
                     self._mark_entry_invalid(entry)


### PR DESCRIPTION
This is to enforce the matching of filename with appid in the project. Until now it was a warning, but moving forward, we need the match.