### PR TITLE
Remove scanner results from /var/lib/atomic

### DIFF
--- a/beanstalk_worker/scanner.py
+++ b/beanstalk_worker/scanner.py
@@ -6,6 +6,7 @@
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 

--- a/beanstalk_worker/scanner.py
+++ b/beanstalk_worker/scanner.py
@@ -26,6 +26,7 @@ logger.addHandler(ch)
 
 
 class Scanner(object):
+
     def __init__(self, image_under_test, scanner_name, full_scanner_name,
                  to_process_output):
         # to be provided by child class
@@ -49,6 +50,16 @@ class Scanner(object):
         # returns out, err
         return process.communicate()
 
+    def clean_scanner_result(self, path):
+        """
+        Clean the scanner  results from /var/lib/atomic directory
+        """
+        try:
+            os.remove(path)
+        except OSError as e:
+            logger.warning("Failed to remove %s" % path)
+            logger.warning("Error: %s" % str(e))
+
     def run(self, cmd):
         # self.image_under_test = image_under_test
         # self.image_id = self.atomic_obj.get_input_id(self.image_under_test)
@@ -66,6 +77,7 @@ class Scanner(object):
 
             if os.path.exists(output_json_file):
                 json_data = json.loads(open(output_json_file).read())
+                self.clean_scanner_result(output_json_file)
             else:
                 logger.log(
                     level=logging.FATAL,

--- a/beanstalk_worker/scanner.py
+++ b/beanstalk_worker/scanner.py
@@ -54,11 +54,9 @@ class Scanner(object):
         """
         Clean the scanner  results from /var/lib/atomic directory
         """
-        try:
-            os.remove(path)
-        except OSError as e:
-            logger.warning("Failed to remove %s" % path)
-            logger.warning("Error: %s" % str(e))
+        scan_result_dir = os.path.dirname(os.path.dirname(path))
+        # TODO: add logging statement here
+        shutil.rmtree(scan_result_dir, ignore_errors=True)
 
     def run(self, cmd):
         # self.image_under_test = image_under_test

--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -273,11 +273,10 @@ class ScannerRPMVerify(object):
         """
         Clean the scanner  results from /var/lib/atomic directory
         """
-        try:
-            os.remove(path)
-        except OSError as e:
-            logger.warning("Failed to remove %s" % path)
-            logger.warning("Error: %s" % str(e))
+        scan_result_dir = os.path.dirname(os.path.dirname(path))
+        logger.info(
+            "Removing extra result copy of scanner: %s" % scan_result_dir)
+        shutil.rmtree(scan_result_dir, ignore_errors=True)
 
     def process_output(self, json_data):
         """
@@ -445,11 +444,10 @@ class PipelineScanner(object):
         """
         Clean the scanner  results from /var/lib/atomic directory
         """
-        try:
-            os.remove(path)
-        except OSError as e:
-            logger.warning("Failed to remove %s" % path)
-            logger.warning("Error: %s" % str(e))
+        scan_result_dir = os.path.dirname(os.path.dirname(path))
+        logger.info(
+            "Removing extra result copy of scanner: %s" % scan_result_dir)
+        shutil.rmtree(scan_result_dir, ignore_errors=True)
 
     def process_output(self, json_data):
         """

--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -20,8 +20,6 @@ BEANSTALKD_HOST = "BEANSTALK_SERVER"
 config.load_logger()
 logger = logging.getLogger("scan-worker")
 
-logger = logging.getLogger("scan-worker")
-
 SCANNERS_OUTPUT = {
     "registry.centos.org/pipeline-images/pipeline-scanner": [
         "image_scan_results.json"],
@@ -115,10 +113,10 @@ class ScannerRunner(object):
         Export scanner logs in given directory
         """
         logs_file_path = os.path.join(
-                self.job_info["logs_dir"],
-                constants.SCANNERS_RESULTFILE[scanner][0])
+            self.job_info["logs_dir"],
+            constants.SCANNERS_RESULTFILE[scanner][0])
         logger.info(
-                "Scanner=%s result log file:%s" % (scanner, logs_file_path)
+            "Scanner=%s result log file:%s" % (scanner, logs_file_path)
         )
         try:
             fin = open(logs_file_path, "w")
@@ -200,8 +198,8 @@ class ScannerRunner(object):
         logger.info("Finished executing all scanners.")
 
         status_file_path = os.path.join(
-                self.job_info["logs_dir"],
-                constants.SCANNERS_STATUS_FILE)
+            self.job_info["logs_dir"],
+            constants.SCANNERS_STATUS_FILE)
         # We export the scanners_status on NFS
         self.export_scanners_status(scanners_data, status_file_path)
 
@@ -256,6 +254,7 @@ class ScannerRPMVerify(object):
 
             if os.path.exists(output_json_file):
                 json_data = json.loads(open(output_json_file).read())
+                self.clean_scanner_result(output_json_file)
             else:
                 logger.fatal("No scan results found at %s" % output_json_file)
                 # FIXME: handle what happens in this case
@@ -269,6 +268,16 @@ class ScannerRPMVerify(object):
             return False, self.process_output(json_data)
 
         return True, self.process_output(json_data)
+
+    def clean_scanner_result(self, path):
+        """
+        Clean the scanner  results from /var/lib/atomic directory
+        """
+        try:
+            os.remove(path)
+        except OSError as e:
+            logger.warning("Failed to remove %s" % path)
+            logger.warning("Error: %s" % str(e))
 
     def process_output(self, json_data):
         """
@@ -415,6 +424,7 @@ class PipelineScanner(object):
 
             if os.path.exists(output_json_file):
                 json_data = json.loads(open(output_json_file).read())
+                self.clean_scanner_result(output_json_file)
             else:
                 logger.fatal(
                     "No scan results found at %s" % output_json_file)
@@ -430,6 +440,16 @@ class PipelineScanner(object):
         logger.info(
             "Finished executing scanner: %s" % self.scanner_name)
         return True, self.process_output(json_data)
+
+    def clean_scanner_result(self, path):
+        """
+        Clean the scanner  results from /var/lib/atomic directory
+        """
+        try:
+            os.remove(path)
+        except OSError as e:
+            logger.warning("Failed to remove %s" % path)
+            logger.warning("Error: %s" % str(e))
 
     def process_output(self, json_data):
         """
@@ -502,6 +522,7 @@ class MiscPackageUpdates(Scanner):
 
 
 class ContainerCapabilities(Scanner):
+
     def __init__(self):
         self.scanner_name = "container-capabilities-scanner"
         self.full_scanner_name = \


### PR DESCRIPTION
This change cleans the original results saved in /var/lib/atomic
directory after scanner execution on given image. Once scanner
finishes execution, results are loaded from default location and written
on NFS disk. Thus there was unnecessary copy of result in /var/lib/atomic
directory. This change removes the extra copy from /var/lib/atomic
thus saves scanner node from running out of disk space.
