### PR TITLE
Fix serilaized builds infinite loop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,8 @@ VAGRANTFILE_API_VERSION = "2"
 
 PROD = (ENV['PROD'] || 0).to_i
 HOME = ENV['HOME']
+TAGS = ENV['TAGS'] || false
+LIMIT = ENV['LIMIT'] || false
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.insert_key = false
@@ -74,8 +76,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           "vagrant",
           "--extra-vars",
           '{"rsync_ssh_opts": "' + rsync_ssh_opts + '"}',
-          "--tags=jenkins/slaves,scanner"
       ]
+      if TAGS
+          ansible.raw_arguments.push('--tags=' + TAGS)
+      end
+      if LIMIT
+          ansible.raw_arguments.push('--limit=' + LIMIT)
+      end
     end
   end
 

--- a/ci/tests/base.py
+++ b/ci/tests/base.py
@@ -28,6 +28,11 @@ class BaseTestCase(unittest.TestCase):
                 'private_key': '~/.vagrant.d/insecure_private_key',
                 'remote_user': 'vagrant'
             },
+            'scanner': {
+                'host': '192.168.100.100',
+                'private_key': '~/.vagrant.d/insecure_private_key',
+                'remote_user': 'vagrant'
+            },
             'controller': {
                 'host': None,
                 'private_key': '~/.vagrant.d/insecure_private_key',
@@ -91,30 +96,30 @@ class BaseTestCase(unittest.TestCase):
         time.sleep(10)
 
     def cleanup_beanstalkd(self):
-        print self.run_cmd('systemctl stop cccp_imagescanner',
+        print self.run_cmd('sudo systemctl stop cccp_imagescanner',
                            host=self.hosts['jenkins_master']['host'])
-        print self.run_cmd('systemctl stop cccp-dockerfile-lint-worker',
+        print self.run_cmd('sudo systemctl stop cccp-dockerfile-lint-worker',
                            host=self.hosts['jenkins_slave']['host'])
-        print self.run_cmd('systemctl stop cccp-scan-worker',
+        print self.run_cmd('sudo systemctl stop cccp-scan-worker',
                            host=self.hosts['scanner']['host'])
-        print self.run_cmd('docker stop build-worker; '
-                           'docker stop delivery-worker; '
-                           'docker stop dispatcher-worker',
+        print self.run_cmd('sudo docker stop build-worker; '
+                           'sudo docker stop delivery-worker; '
+                           'sudo docker stop dispatcher-worker',
                            host=self.hosts['jenkins_slave']['host'])
 
-        print self.run_cmd('systemctl restart beanstalkd',
+        print self.run_cmd('sudo systemctl restart beanstalkd',
                            host=self.hosts['openshift']['host'])
         time.sleep(5)
 
-        print self.run_cmd('docker start build-worker; '
-                           'docker start delivery-worker; '
-                           'docker start dispatcher-worker',
+        print self.run_cmd('sudo docker start build-worker; '
+                           'sudo docker start delivery-worker; '
+                           'sudo docker start dispatcher-worker',
                            host=self.hosts['jenkins_slave']['host'])
-        print self.run_cmd('systemctl start cccp-dockerfile-lint-worker',
+        print self.run_cmd('sudo systemctl start cccp-dockerfile-lint-worker',
                            host=self.hosts['jenkins_slave']['host'])
-        print self.run_cmd('systemctl start cccp-scan-worker',
+        print self.run_cmd('sudo systemctl start cccp-scan-worker',
                            host=self.hosts['scanner']['host'])
-        print self.run_cmd('systemctl start cccp_imagescanner',
+        print self.run_cmd('sudo systemctl start cccp_imagescanner',
                            host=self.hosts['jenkins_master']['host'])
 
     def get_jenkins_builds_for_job(self, job):

--- a/ci/tests/test_00_openshift/__init__.py
+++ b/ci/tests/test_00_openshift/__init__.py
@@ -117,17 +117,26 @@ class TestOpenshift(BaseTestCase):
             'centos-kubernetes-master-latest').hexdigest()
         k8s_apiserver_os_project = hashlib.sha224(
             'centos-kubernetes-apiserver-latest').hexdigest()
+
+        # Assert that lock file for centos-kubernetes-master-latest exists
+        self.assertTrue(self.run_cmd(
+            'ls /srv/pipeline-logs/centos-kubernetes-master-latest'))
         self.assertOsProjectBuildStatus(
             k8s_master_os_project, ['build-1', 'test-1', 'delivery-1'],
             'Complete', retries=80, delay=15
         )
+
+        time.sleep(10)
+
+        # Assert that lock file for centos-kubernetes-master-latest does not
+        # exist anymore
+        self.assertRaises(
+            Exception,
+            self.run_cmd,
+            'ls /srv/pipeline-logs/centos-kubernetes-master-latest')
 
         # Assert that delivery of centos-kubernetes-master-latest triggered
         # build for centos-kubernetes-apiserver-latest
         self.assertOsProjectBuildStatus(
             k8s_apiserver_os_project, ['build-1'], 'Running', retries=6,
             delay=30)
-        self.assertRaises(
-            Exception,
-            self.run_cmd,
-            'ls /srv/pipeline-logs/centos-kubernetes-master-latest')

--- a/ci/tests/test_00_openshift/__init__.py
+++ b/ci/tests/test_00_openshift/__init__.py
@@ -17,8 +17,8 @@ class TestOpenshift(BaseTestCase):
         oc_config = (
             '/var/lib/origin/openshift.local.config/master/admin.kubeconfig')
         cmd = (
-            "oc --config {config} project {project} > /dev/null && "
-            "oc --config {config} get builds".format(
+            "sudo oc --config {config} project {project} > /dev/null && "
+            "sudo oc --config {config} get builds".format(
                 config=oc_config, project=project)
         )
         retry_count = 0
@@ -49,16 +49,16 @@ class TestOpenshift(BaseTestCase):
         self.cleanup_openshift()
         self.cleanup_beanstalkd()
         print self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar '
+            'sudo java -jar /opt/jenkins-cli.jar '
             '-s http://localhost:8080 enable-job bamachrn-python-release',
             host=self.hosts['jenkins_master']['host'])
         print self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar '
+            'sudo java -jar /opt/jenkins-cli.jar '
             '-s http://localhost:8080 '
             'build bamachrn-python-release -f -v',
             host=self.hosts['jenkins_master']['host'])
         print self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar '
+            'sudo java -jar /opt/jenkins-cli.jar '
             '-s http://localhost:8080 disable-job bamachrn-python-release',
             host=self.hosts['jenkins_master']['host'])
 
@@ -82,20 +82,20 @@ class TestOpenshift(BaseTestCase):
         self.cleanup_beanstalkd()
         self.cleanup_openshift()
         _print(self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s '
+            'sudo java -jar /opt/jenkins-cli.jar -s '
             'http://localhost:8080 enable-job '
             'centos-kubernetes-master-latest',
             host=self.hosts['jenkins_master']['host']))
         _print(self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s '
+            'sudo java -jar /opt/jenkins-cli.jar -s '
             'http://localhost:8080 enable-job '
             'centos-kubernetes-apiserver-latest',
             host=self.hosts['jenkins_master']['host']))
         k8s_apiserver_prev_builds = self.get_jenkins_builds_for_job(
             'centos-kubernetes-apiserver-latest')
         _print(self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s http://localhost:8080 build '
-            'centos-kubernetes-master-latest -f -v',
+            'sudo java -jar /opt/jenkins-cli.jar -s http://localhost:8080 '
+            'build centos-kubernetes-master-latest -f -v',
             host=self.hosts['jenkins_master']['host']
         ))
         time.sleep(10)
@@ -104,12 +104,12 @@ class TestOpenshift(BaseTestCase):
         self.assertTrue(
             len(k8s_apiserver_cur_builds) > len(k8s_apiserver_prev_builds))
         _print(self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s '
+            'sudo java -jar /opt/jenkins-cli.jar -s '
             'http://localhost:8080 disable-job '
             'centos-kubernetes-master-latest',
             host=self.hosts['jenkins_master']['host']))
         _print(self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s '
+            'sudo java -jar /opt/jenkins-cli.jar -s '
             'http://localhost:8080 disable-job '
             'centos-kubernetes-apiserver-latest',
             host=self.hosts['jenkins_master']['host']))

--- a/container_pipeline/lib/default_settings.py
+++ b/container_pipeline/lib/default_settings.py
@@ -159,3 +159,6 @@ JENKINS_CLI = '/opt/jenkins-cli.jar'
 CONTAINER_BUILD_TRIGGER_DELAY = 10
 UPSTREAM_PACKAGE_CACHE = os.path.join(BASE_DIR, 'tracking/data')
 BEANSTALK_SERVER = 'localhost'
+
+# Build worker
+BUILD_RETRY_DELAY = os.environ.get('BUILD_RETRY_DELAY') or 120  # in seconds

--- a/container_pipeline/workers/base.py
+++ b/container_pipeline/workers/base.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 
 from container_pipeline.lib import settings
 from container_pipeline.lib.queue import JobQueue
@@ -49,17 +50,27 @@ class BaseWorker(object):
         while True:
             job_obj = self.queue.get()
             job = json.loads(job_obj.body)
-            debug_logs_file = os.path.join(
-                job['logs_dir'], settings.SERVICE_LOGFILE)
-            # Run dfh.clean() to clean log files if no error is encountered in
-            # post delivering build report mails to user
-            dfh = DynamicFileHandler(self.logger, debug_logs_file)
-            self.logger.info('Got job: {}'.format(job))
-            try:
-                self.handle_job(job)
-            except Exception as e:
-                self.logger.error(
-                    'Error in handling job: {}\nJob details: {}'.format(
-                        e, job), extra={'locals': locals()}, exc_info=True)
-            dfh.remove()
+
+            # Skip retrying a job if it's too early and push it back to queue.
+            # This will allow us to introduce some delays between job retries
+            if job.get('retry') is True and (
+                    time.time() - job.get('last_run_timestamp', 0) < job.get(
+                        'retry_delay', 0)):
+                time.delay(10)
+                self.queue.put(json.dumps(job), 'master_tube')
+            else:
+                debug_logs_file = os.path.join(
+                    job['logs_dir'], settings.SERVICE_LOGFILE)
+                # Run dfh.clean() to clean log files if no error is
+                # encountered in post delivering build report mails to user
+                dfh = DynamicFileHandler(self.logger, debug_logs_file)
+                self.logger.info('Got job: {}'.format(job))
+                try:
+                    self.handle_job(job)
+                except Exception as e:
+                    self.logger.error(
+                        'Error in handling job: {}\nJob details: {}'.format(
+                            e, job), extra={'locals': locals()}, exc_info=True
+                    )
+                dfh.remove()
             self.queue.delete(job_obj)


### PR DESCRIPTION
Fixes #271 

Changes

- Add delay between build job retries, when parent build/test/scan/delivery is in progress

Benefits:
- This will help us rate limit the number of times we process/retry to process a job for build
- This will prevent generating unnecessary logs when processing a build job