### PR TITLE
Changes service debug log file extention to .txt

### DIFF
--- a/beanstalk_worker/config.py
+++ b/beanstalk_worker/config.py
@@ -6,7 +6,7 @@ LOG_LEVEL = 'DEBUG'
 
 LOG_PATH = '/srv/pipeline-logs/cccp.log'
 
-SERVICE_LOGFILE = "service_debug.log"
+SERVICE_LOGFILE = "service_debug_log.txt"
 
 LOGGING_CONF = dict(
     version=1,

--- a/beanstalk_worker/worker_start_scan.py
+++ b/beanstalk_worker/worker_start_scan.py
@@ -584,7 +584,7 @@ while True:
         job_info = json.loads(job.body)
 
         debug_logs_file = os.path.join(
-            job_info["logs_dir"], "service_debug.log")
+            job_info["logs_dir"], "service_debug_log.txt")
         dfh = config.DynamicFileHandler(logger, debug_logs_file)
 
         logger.info('Got job: %s' % job_info)

--- a/container_pipeline/lib/default_settings.py
+++ b/container_pipeline/lib/default_settings.py
@@ -8,7 +8,7 @@ import os
 
 LOG_LEVEL = os.environ.get('LOG_LEVEL') or 'DEBUG'
 LOG_PATH = '/srv/pipeline-logs/cccp.log'
-SERVICE_LOGFILE = "service_debug.log"
+SERVICE_LOGFILE = "service_debug_log.txt"
 
 # Django specific configuration
 TIME_ZONE = 'UTC'

--- a/container_pipeline/workers/scan.py
+++ b/container_pipeline/workers/scan.py
@@ -8,6 +8,7 @@ import os
 import container_pipeline.lib.log as log
 from container_pipeline.workers.base import BaseWorker
 from container_pipeline.scanners.runner import ScannerRunner
+from container_pipeline.lib import settings
 
 
 class ScanWorker(BaseWorker):
@@ -21,7 +22,7 @@ class ScanWorker(BaseWorker):
         this calls the ScannerRunner for performing the scan work
         """
         debug_logs_file = os.path.join(
-            job["logs_dir"], "service_debug.log")
+            job["logs_dir"], settings.SERVICE_LOGFILE)
         dfh = log.DynamicFileHandler(logger, debug_logs_file)
 
         self.logger.info('Got job: {}'.format(job))

--- a/mail_service/config.py
+++ b/mail_service/config.py
@@ -6,7 +6,7 @@ LOG_LEVEL = 'DEBUG'
 
 LOG_PATH = '/srv/pipeline-logs/cccp.log'
 
-SERVICE_LOGFILE = "service_debug.log"
+SERVICE_LOGFILE = "service_debug_log.txt"
 
 LOGGING_CONF = dict(
     version=1,

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -332,10 +332,10 @@ class NotifyUser(object):
                     self.job_info["notify_email"])
         self.send_email(subject, email_contents)
 
-        # if it is a weekly scan, return True to delete service_debug.log
+        # if it is a weekly scan, return True to delete service_debug_log.txt
         if self.job_info.get("weekly", False):
             return True
-        # if build status if False, do not delete service_debug.log
+        # if build status if False, do not delete service_debug_log.txt
         return self.job_info.get("build_status", False)
 
     def remove_status_files(self, status_files):


### PR DESCRIPTION
  This changeset updates settings for CCCP service debug log file
  extension from .log to .txt

  Earlier the service debug file name was `service_debug.log`, now it
  is `service_debug_log.txt`. This file resides under `/srv/pipeline-logs/{logs_dir}/`
  folder. This file contains service debug logs for the particular build.

  We keep this log file per build for failed builds or builds having exceptions for
  debug purpose. When a build fails, service devs / user can see this file in browser
  along with logs directory contents. The link is given in notification in email to user.
  Having `.txt` extension should help view logs directly in browser than downloading the file and
  viewing in text editor.