### PR TITLE
Updates OS test-admin user policy to admin user

### DIFF
--- a/provisions/roles/openshift/tasks/setup.yml
+++ b/provisions/roles/openshift/tasks/setup.yml
@@ -23,13 +23,12 @@
 - name: Wait for Openshift Router to come up
   pause: seconds={{ openshift_startup_delay }}
 
-- name: Create test user
+- name: Create test user and add role to user
   command: "{{ item }}"
   with_items:
-    - "oadm policy add-role-to-user view test-admin --config={{ kubeconfig }}"
+    - "oadm policy add-role-to-user admin test-admin --config={{ kubeconfig }}"
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
-  ignore_errors: yes
 
 - name: Create image pruner for cleaning up the system
   command: "{{ item }}"


### PR DESCRIPTION
  Earlier we had `test-admin` user configured with `view` role.
  This changeset configures `test-admin` user with `admin` role.
  Also, the provisioning bits are modified to not ignore errors.
  We need to make sure, during the deployment policy is added to user
  and not ignore errors. This is must since the user needs to have proper access.