### PR TITLE
Not to repeat failed builds

### DIFF
--- a/container_pipeline/pipeline.py
+++ b/container_pipeline/pipeline.py
@@ -60,7 +60,7 @@ def create_project(appid, jobid, repo_url, repo_branch, repo_build_path,
             'depends_on': depends_on,
             'logs_dir': '/srv/pipeline-logs/{}'.format(test_tag),
             'TEST_TAG': test_tag
-        }))
+        }), 'master_tube')
     else:
         logger.error("Jenkins is not able to setup openshift project")
 

--- a/container_pipeline/workers/build.py
+++ b/container_pipeline/workers/build.py
@@ -4,12 +4,12 @@ import logging
 import os
 import time
 
-from container_pipeline.utils import Build, get_job_name, get_project_name, \
-    get_job_hash
+from container_pipeline.lib import settings
 from container_pipeline.lib.log import load_logger
 from container_pipeline.lib.openshift import Openshift, OpenshiftError
+from container_pipeline.utils import (Build, get_job_hash, get_job_name,
+                                      get_project_name)
 from container_pipeline.workers.base import BaseWorker
-from container_pipeline.lib import settings
 
 
 class BuildWorker(BaseWorker):
@@ -87,7 +87,9 @@ class BuildWorker(BaseWorker):
 
     def handle_build_failure(self, job):
         """Handle build failure for job"""
-        self.queue.put(json.dumps(job))
+        job.pop('action', None)
+        job['action'] = "build_failure"
+        self.queue.put(json.dumps(job), 'master_tube')
         self.logger.warning(
             "Build is not successful putting it to failed build tube")
         data = {

--- a/container_pipeline/workers/delivery.py
+++ b/container_pipeline/workers/delivery.py
@@ -6,9 +6,9 @@ import os
 
 from container_pipeline.lib.log import load_logger
 from container_pipeline.lib.openshift import Openshift, OpenshiftError
+from container_pipeline.utils import (Build, get_job_hash, get_job_name,
+                                      get_project_name)
 from container_pipeline.workers.base import BaseWorker
-from container_pipeline.utils import get_job_name, get_project_name, \
-    get_job_hash, Build
 
 
 class DeliveryWorker(BaseWorker):
@@ -84,7 +84,9 @@ class DeliveryWorker(BaseWorker):
         Puts the job back to the delivery tube for later attempt at delivery
         and requests to notify the user about failure to deliver
         """
-        self.queue.put(json.dumps(job))
+        job.pop('action', None)
+        job['action'] = "delivery_failure"
+        self.queue.put(json.dumps(job), 'master_tube')
         self.logger.warning(
             "Delivery is not successful putting it to failed delivery tube")
         data = {

--- a/container_pipeline/workers/worker_test.py
+++ b/container_pipeline/workers/worker_test.py
@@ -3,9 +3,9 @@ import json
 import logging
 import os
 
-from container_pipeline.utils import Build, get_job_name, get_project_name
 from container_pipeline.lib.log import load_logger
 from container_pipeline.lib.openshift import Openshift, OpenshiftError
+from container_pipeline.utils import Build, get_job_name, get_project_name
 from container_pipeline.workers.base import BaseWorker
 
 
@@ -51,7 +51,9 @@ class TestWorker(BaseWorker):
 
     def handle_test_failure(self, job):
         """Handle test failure for job"""
-        self.queue.put(json.dumps(job))
+        job.pop('action', None)
+        job['action'] = "test_failure"
+        self.queue.put(json.dumps(job), 'master_tube')
         self.logger.warning(
             "Test is not successful putting it to failed build tube")
         data = {


### PR DESCRIPTION
Changed actions for failed builds, so that they do not repeat. if the action remains same it keeps on going to the same loop