### PR TITLE
Fixes linter command invocation via library run_cmd

### DIFF
--- a/container_pipeline/workers/linter.py
+++ b/container_pipeline/workers/linter.py
@@ -46,9 +46,8 @@ class DockerfileLintWorker(BaseWorker):
         """
         Lint the Dockerfile received
         """
-        command = ["docker", "run", "--rm", "-v", "/tmp/scan:/root/scan:Z",
-                   "registry.centos.org/pipeline-images/dockerfile-lint"]
-
+        command = ("docker run --rm -v /tmp/scan:/root/scan:Z "
+                   "registry.centos.org/pipeline-images/dockerfile-lint")
         try:
             out = run_cmd(command)
         except Exception as e:


### PR DESCRIPTION
  Library `run_cmd` function takes string or list.
  One needs to pass list if caller wants `shell=True`, else just pass
  command as a string. This changeset fixes linter invocation, it does not
  need `shell=True`, and it was earlier using list to send command.
  Fixed it to send invocation commmand as string instead of list.