### PR TITLE
Syncs jenkins jobs with container index entries

### DIFF
--- a/container_pipeline/lib/default_settings.py
+++ b/container_pipeline/lib/default_settings.py
@@ -111,6 +111,11 @@ LOGGING = dict(
             "propagate": False,
             "handlers": ["console", "log_to_file"]
 
+        },
+        'cccp-index-reader': {
+            "level": "DEBUG",
+            "propogate": False,
+            "handlers": ["console", "log_to_file"]
         }
     },
 )

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -185,7 +185,7 @@ def delete_stale_projects_on_jenkins(stale_projects):
     for project in stale_projects:
         myargs = ["jenkins-jobs", "delete", project]
         # print either output or error
-        out, error = run_command(myargs)
+        _, error = run_command(myargs)
         if error:
             logger.critical("Failed to delete project %s. Exiting..", project)
             logger.critical(sys.exc_info()[0])
@@ -228,7 +228,12 @@ def main(indexdlocation):
                       ':'.join(
                           [jjb_defaults_file, generated_filename])
                       ]
-            run_command(myargs)
+            _, error = run_command(myargs)
+            if error:
+                logger.critical("Error %s running command %s" % (
+                    error, str(myargs)))
+                logger.critical("Project details: %s ", str(project))
+                exit(1)
 
             new_projects_names.append(
                 str(project[0]["project"]["appid"]) + "-" +
@@ -238,6 +243,7 @@ def main(indexdlocation):
         except Exception as e:
             logger.critical("Error updating jenkins job via file %s",
                             generated_filename)
+            logger.critical("Project details: %s", str(project))
             logger.critical(str(e))
             # if jenkins job update fails, the cccp-index job should fail
             logger.critical(sys.exc_info()[0])

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -122,6 +122,10 @@ def export_new_project_names(projects_names):
     with open(projects_list, "w") as fin:
         fin.write(projects_names)
 
+    # change the mod of file so that jenkins user can edit it
+    print "Changing file permission 0777 of file %s" % projects_list
+    run_command(["chmod", "0777", projects_list])
+
 
 def get_old_project_list():
     """

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -8,6 +8,15 @@ import sys
 import tempfile
 import yaml
 
+# populate container_pipeline module path
+cp_module_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "container_pipeline"
+        )
+# add path of modules to system path for imports
+sys.path.append(os.path.dirname(cp_module_path))
+sys.path.append(cp_module_path)
+
 from container_pipeline.lib.log import load_logger
 
 from glob import glob

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -10,6 +10,14 @@ import yaml
 
 jjb_defaults_file = 'project-defaults.yml'
 
+# pathname of file having all project names
+# this file will be generated after first run
+# and will reside in same directory as of this python file
+projects_list = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "all_projects_names.txt"
+)
+
 required_attrs = ['image_name', 'image_version']
 optional_attrs = ['rundotshargs']
 overwritten_attrs = ['jobid', 'git_url', 'appid', 'jobs']
@@ -100,16 +108,83 @@ def get_projects_from_index(indexdlocation):
                                 dependson, notifyemail, desiredtag)
                         )
                     except Exception as e:
+                        print e
                         raise
     return projects
 
 
+def export_new_project_names(projects_names):
+    """
+    Exports the name of project
+    """
+    # opens the file defined at the start of this script
+    projects_names = "\n".join(projects_names)
+    with open(projects_list, "w") as fin:
+        fin.write(projects_names)
+
+
+def get_old_project_list():
+    """
+    This function retuns the list of projects that were indexed
+    during last run of cccp-index job. It returns [] empty list
+    if it can not find the project list.
+    """
+    if not os.path.exists(projects_list):
+        print "%s does not exist. This is first run or file is absent." \
+            % projects_list
+        return []
+    with open(projects_list) as fin:
+        old_projects = fin.read()
+    return list(set(old_projects.strip().split("\n")))
+
+
+def find_stale_projects(old, new):
+    """
+    This function diffs the old project list with new project
+    list. And returns the list of project names to be deleted
+    """
+    return list(set(old) - set(new))
+
+
+def delete_stale_projects_on_jenkins(stale_projects):
+    """
+    This function deletes the stale entries at jenkins that
+    are no longer valid. If there is any issue/exception, it
+    bypasses by printing the error.
+    """
+    for project in stale_projects:
+        myargs = ["jenkins-jobs", "delete", project]
+        # print either output or error
+        print run_command(myargs)
+
+
+def delete_stale_projects_on_openshift():
+    """
+    Stale projects found on jenkins need to be deleted
+    accordingly on OpenShift as well. This function maps
+    the project names from jenkins to openshift and deletes them.
+    (see delete_stale_projects_on_jenkins function)
+    """
+    pass
+
+
+def run_command(command):
+    """
+    runs the given shell command using subprocess
+    """
+    proc = subprocess.Popen(command,
+                            stdout=subprocess.PIPE)
+
+    return proc.communicate()
+
+
 def main(indexdlocation):
+    new_projects_names = []
     for project in get_projects_from_index(indexdlocation):
         try:
             # workdir = os.path.join(t, gitpath)
             t = tempfile.mkdtemp()
-            print "creating: {}".format(t)
+            # print "creating: {}".format(t)
             generated_filename = os.path.join(
                 t,
                 'cccp_GENERATED.yaml'
@@ -118,7 +193,6 @@ def main(indexdlocation):
             # projectify
             with open(generated_filename, 'w') as outfile:
                 yaml.dump(project, outfile)
-
             # run jenkins job builder
             myargs = ['jenkins-jobs',
                       '--ignore-cache',
@@ -126,15 +200,34 @@ def main(indexdlocation):
                       ':'.join(
                           [jjb_defaults_file, generated_filename])
                       ]
-            print myargs
-            proc = subprocess.Popen(myargs,
-                                    stdout=subprocess.PIPE)
-            proc.communicate()
+            run_command(myargs)
 
+            new_projects_names.append(
+                str(project[0]["project"]["appid"]) + "-" +
+                str(project[0]["project"]["jobid"]) + "-" +
+                str(project[0]["project"]["desired_tag"])
+            )
         finally:
-            print "Removing {}".format(t)
-            # shutil.rmtree(t)
+            pass
+    # get list of old projects
+    old_projects = get_old_project_list()
 
+    # find stale projects
+    stale_projects = find_stale_projects(
+        old_projects,
+        list(set(new_projects_names))
+    )
+
+    print stale_projects
+
+    # delete stale entries at jenkins
+    delete_stale_projects_on_jenkins(stale_projects)
+
+    # delete stale entries at openshift
+    delete_stale_projects_on_openshift()
+
+    # export the current projects_list in file
+    export_new_project_names(new_projects_names)
 
 if __name__ == '__main__':
     main(sys.argv[1])

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -119,12 +119,18 @@ def export_new_project_names(projects_names):
     """
     # opens the file defined at the start of this script
     projects_names = "\n".join(projects_names)
-    with open(projects_list, "w") as fin:
-        fin.write(projects_names)
-
-    # change the mod of file so that jenkins user can edit it
-    print "Changing file permission 0777 of file %s" % projects_list
-    run_command(["chmod", "0777", projects_list])
+    try:
+        with open(projects_list, "w") as fin:
+            fin.write(projects_names)
+    except IOError as e:
+        print "Failed to export project names to file %s" % projects_list
+        print "I/O Error {0}:{1}".format(e.errno, e.strerror)
+    except:
+        print "Unexpected error:", sys.exc_info()[0]
+    else:
+        # change the mod of file so that jenkins user can edit it
+        print "Changing file permission 0777 of file %s" % projects_list
+        run_command(["chmod", "0777", projects_list])
 
 
 def get_old_project_list():


### PR DESCRIPTION
  Fixes #310
  This changeset adds option to `jenkins-job` command to delete old
  project while updating it per index.