### PR TITLE
Configures email subject prefix

### DIFF
--- a/ci/lib.py
+++ b/ci/lib.py
@@ -164,6 +164,7 @@ setup_nfs=True
 production=False
 log_level=DEBUG
 openshift_server_ip={openshift_host}
+deployment=ci
 
 [jenkins_master:vars]
 jenkins_private_key_file = jenkins.key

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -132,19 +132,19 @@ class NotifyUser(object):
         If given production as value, the subject is kept intact, else
         the value is pre-pended with the subject. Like [test] SUCCESS [..]
         """
-        environment = os.environ.get("ENVIRONMENT", False)
+        deployment = os.environ.get("DEPLOYMENT", False)
 
-        logger.debug("Got environment variable ENVIRONMENT=%s", environment)
+        logger.debug("Got environment variable DEPLOYMENT=%s", deployment)
         # if environment variable is not found, consider production
-        if not environment:
+        if not deployment:
             return subject
 
         # case insensitive check for string 'production'
-        elif environment.strip().lower() == "production":
+        elif deployment.strip().lower() == "production":
             # default is production environment
             return subject
         else:
-            return "[" + environment + "] " + subject
+            return "[" + deployment + "] " + subject
 
     def send_email(self, subject, contents):
         "Sends email to user"

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -128,26 +128,22 @@ class NotifyUser(object):
     def update_subject_of_email(self, subject):
         """
         Mail server container is created with a environment variable
-        "PRODUCTION", its value is either True or False (Bool).
+        "ENVIRONMENT", its value should be among [production,pre-prod,test].
+        If given production as value, the subject is kept intact, else
+        the value is pre-pended with the subject. Like [test] SUCCESS [..]
         """
-        # Default case (if no env var found): It is production.
-        # PRODUCTION = "True" : no prepending
-        # PRODUCTION = "False" or any other value : prepend [test] in subject
+        environment = os.environ.get("ENVIRONMENT", False)
 
-        # if var's value is "True" and even if the env variable is not found
-        # (since first priority is production)
+        # if environment variable is not found, consider production
+        if not environment:
+            return subject
 
-        if not os.environ.get("PRODUCTION", False) or \
-           os.environ.get("PRODUCTION") == "True":
-            # production
-
-            # no change
+        # case insensitive check for string 'production'
+        elif environment.strip().lower() == "production":
+            # default is production environment
             return subject
         else:
-            # for any other value of "PRODUCTION" environment variable if set
-
-            # alter subject
-            return "[test] " + subject
+            return "[" + environment + "] " + subject
 
     def send_email(self, subject, contents):
         "Sends email to user"

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -28,8 +28,8 @@ SUCCESS_EMAIL_SUBJECT = "SUCCESS: Container build: %s is complete"
 FAILURE_EMAIL_SUBJECT = "FAILED: Container build: %s is failed"
 WEEKLY_EMAIL_SUBJECT = "Weekly scanning results for image: %s"
 
-EMAIL_HEADER = """
-CentOS Community Container Pipeline Service <https://github.com/centos/container-index>"""
+EMAIL_HEADER = ("CentOS Community Container Pipeline Service "
+                "<https://github.com/centos/container-index>")
 
 EMAIL_HEADER = EMAIL_HEADER + "\n" + "=" * (len(EMAIL_HEADER) - 22)
 
@@ -134,6 +134,7 @@ class NotifyUser(object):
         """
         environment = os.environ.get("ENVIRONMENT", False)
 
+        logger.debug("Got environment variable ENVIRONMENT=%s", environment)
         # if environment variable is not found, consider production
         if not environment:
             return subject

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -41,16 +41,16 @@ https://wiki.centos.org/ContainerPipeline
 """
 
 SUCCESS_EMAIL_MSG = """
-Build status:   Success
-Image:          %s
-Build logs:     %s
+Build status:\t\tSuccess
+Image:\t\t%s
+Build logs:\t\t%s
 """
 
 FAILURE_EMAIL_MSG = """
 Container build %s is failed due to error in build or test steps.
 
-Build status:   Failure
-Build logs:     %s
+Build status:\t\tFailure
+Build logs:\t\t%s
 """
 
 LINTER_RESULTS = """

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -42,7 +42,7 @@ https://wiki.centos.org/ContainerPipeline
 
 SUCCESS_EMAIL_MSG = """
 Build status:\t\tSuccess
-Image:\t\t%s
+Image:\t\t\t%s
 Build logs:\t\t%s
 """
 

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -32,9 +32,10 @@ setup_nfs=False
 # replace scanner_worker below with its FQDN / IP
 #test_nfs_share=scanner_worker:/nfsshare
 
-# for distinguishing emails from production or devcloud
-# keep it True for production and False for non production
-production=True
+# for distinguishing emails from production, pre-prod, test environments
+# give either value among [production, pre-prod, test]
+# default is production
+environment=production
 
 # Set log level
 log_level = DEBUG

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -35,7 +35,7 @@ setup_nfs=False
 # for distinguishing emails from production, pre-prod, test environments
 # give either value among [production, pre-prod, test]
 # default is production
-environment=production
+deployment=production
 
 # Set log level
 log_level = DEBUG

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -34,4 +34,4 @@
       volumes:
         /srv/pipeline-logs:/srv/pipeline-logs:rw
       env:
-        ENVIRONMENT: "{{deployment}}"
+        DEPLOYMENT: "{{deployment}}"

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -34,4 +34,4 @@
       volumes:
         /srv/pipeline-logs:/srv/pipeline-logs:rw
       env:
-        ENVIRONMENT: "{{environment}}"
+        ENVIRONMENT: "{{deployment}}"

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -26,7 +26,6 @@
       chdir: "{{ ansible_env.HOME }}/cccp-service/mail_service"
 
 - name: Start Mail Service
-  when: production
   docker_container:
       name: mail-server
       state: started
@@ -35,16 +34,4 @@
       volumes:
         /srv/pipeline-logs:/srv/pipeline-logs:rw
       env:
-        PRODUCTION: True
-
-- name: Start Mail Service
-  when: not production
-  docker_container:
-    name: mail-server
-    state: started
-    image: mail-server
-    restart_policy: unless-stopped
-    volumes:
-      /srv/pipeline-logs/:/srv/pipeline-logs:rw
-    env:
-      PRODUCTION: False
+        ENVIRONMENT: "{{production}}"

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -34,4 +34,4 @@
       volumes:
         /srv/pipeline-logs:/srv/pipeline-logs:rw
       env:
-        ENVIRONMENT: "{{production}}"
+        ENVIRONMENT: "{{environment}}"


### PR DESCRIPTION
This PR improves the option to configure email subject prefix using variable in hosts file.
Earlier there were only two possible options for this, test and production environment.
With this changeset, a user will be able to configure, either production, pre-prod, or test environment and accordingly email can be distinguished.