### PR TITLE
Updates ansible docker module operations

### DIFF
--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -19,48 +19,49 @@
   file: dest=/opt/cccp-service/beanstalk_worker state=directory
 
 - name: Build container-pipeline image
-  shell: docker build -t container-pipeline -f ./Dockerfile .
-  args:
-      chdir: /opt/cccp-service
+  sudo: yes
+  docker_image:
+    name: container-pipeline
+    path: /opt/cccp-service
   tags:
       - application
 
 - name: Ensure log path exists
   file: path=/srv/pipeline-logs/cccp.log state=touch
 
-- name: Start dispatcher worker
-  docker:
+- name: Start dispatcher-worker container
+  docker_container:
       name: dispatcher-worker
-      state: restarted
+      state: present
+      restart: yes
       image: container-pipeline
       command: /opt/cccp-service/container_pipeline/workers/dispatcher.py
       restart_policy: always
-      volumes:
-        /srv/pipeline-logs:/srv/pipeline-logs:rw
+      volumes: /srv/pipeline-logs:/srv/pipeline-logs:rw
   tags:
       - application
 
-- name: Start build worker
-  docker:
+- name: Start build-worker container
+  docker_container:
       name: build-worker
-      state: restarted
+      state: present
+      restart: yes
       image: container-pipeline
       command: /opt/cccp-service/container_pipeline/workers/build.py
       restart_policy: always
-      volumes:
-        /srv/pipeline-logs:/srv/pipeline-logs:rw
+      volumes: /srv/pipeline-logs:/srv/pipeline-logs:rw
   tags:
       - application
 
-- name: Start delivery worker
-  docker:
+- name: Start delivery-worker container
+  docker_container:
       name: delivery-worker
-      state: restarted
+      state: present
+      restart: yes
       command: /opt/cccp-service/container_pipeline/workers/delivery.py
       image: container-pipeline
       restart_policy: always
-      volumes:
-        /srv/pipeline-logs:/srv/pipeline-logs:rw
+      volumes: /srv/pipeline-logs:/srv/pipeline-logs:rw
   tags:
       - application
 

--- a/provisions/roles/openshift/tasks/config.yml
+++ b/provisions/roles/openshift/tasks/config.yml
@@ -33,17 +33,17 @@
       - "{{ origin_image_registry }}/{{ origin_image_name }}-docker-registry"
       - "{{ origin_image_registry }}/{{ origin_image_name }}-sti-builder"
 
-- name: Run openshift docker image
-  docker:
+- name: Create OpenShift origin container
+  docker_container:
     name: origin
     image: "{{ origin_image_registry }}/{{ origin_image_name }}:{{ origin_image_tag }}"
     privileged: yes
-    pid: host
-    net: host
+    pid_mode: host
+    network_mode: host
     volumes: "{{ openshift_volumes }}"
     command: start --master=https://"{{ansible_default_ipv4.address}}":8443
     restart_policy: always
-  retries: 2
+    restart_retries: 2
 
 - name: Wait for Openshift to come up
   pause: seconds={{ openshift_startup_delay }}

--- a/provisions/roles/openshift/tasks/setup.yml
+++ b/provisions/roles/openshift/tasks/setup.yml
@@ -47,16 +47,19 @@
       - "{{ rsync_ssh_opts }}"
 
 - name: Build cccp build image
-  shell: docker build -t cccp-build -f ./Dockerfile.build .
-  args:
-      chdir: "{{ ansible_env.HOME }}/cccp-service/server"
+  docker_image:
+    path: "{{ ansible_env.HOME }}/cccp-service/server"
+    name: cccp-build
+    dockerfile: Dockerfile.build
 
 - name: Build cccp test image
-  shell: docker build -t cccp-test -f ./Dockerfile.test .
-  args:
-      chdir: "{{ ansible_env.HOME }}/cccp-service/server"
+  docker_image:
+    path: "{{ ansible_env.HOME }}/cccp-service/server"
+    name: cccp-test
+    dockerfile: Dockerfile.test
 
 - name: Build cccp delivery image
-  shell: docker build -t cccp-delivery -f ./Dockerfile.delivery .
-  args:
-      chdir: "{{ ansible_env.HOME }}/cccp-service/server"
+  docker_image:
+    path: "{{ ansible_env.HOME }}/cccp-service/server"
+    name: cccp-delivery
+    dockerfile: Dockerfile.delivery

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -15,7 +15,7 @@
   replace: >
       dest="{{ ansible_env.HOME }}/cccp-service/mail_service/config.py"
       regexp="LOG_LEVEL =.*"
-      replace= "LOG_LEVEL = '{{ log_level }}'"
+      replace="LOG_LEVEL = '{{ log_level }}'"
 
 - name: Build mail-server container image
   sudo: yes

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -3,27 +3,26 @@
 - name: Ensure log path exists
   file: path=/srv/pipeline-logs/cccp.log state=touch
 
-- name: Stop Mail Service
-  shell: docker rm -f mail-server
-  register: result
-  until: result['rc'] == 0 or result['stderr'].find('No such container') >= 0
-  retries: 10
-  delay: 10
+- name: Stop mail-server container
+  sudo: yes
   ignore_errors: true
-
-- name: Print result
-  debug: msg="Result= {{ result }}"
+  docker_container:
+    name: mail-server
+    state: absent
+    force_kill: true
 
 - name: Set log level
   replace: >
       dest="{{ ansible_env.HOME }}/cccp-service/mail_service/config.py"
       regexp="LOG_LEVEL =.*"
-      replace="LOG_LEVEL = '{{ log_level }}'"
+      replace= "LOG_LEVEL = '{{ log_level }}'"
 
-- name: Build mail server image
-  shell: docker build -t mail-server -f ./Dockerfile.mailserv .
-  args:
-      chdir: "{{ ansible_env.HOME }}/cccp-service/mail_service"
+- name: Build mail-server container image
+  sudo: yes
+  docker_image:
+    name: mail-server
+    path: "{{ ansible_env.HOME }}/cccp-service/mail_service"
+    dockerfile: Dockerfile.mailserv
 
 - name: Start Mail Service
   docker_container:


### PR DESCRIPTION
Ansible `docker` module is deprecated, `docker_image` and `docker_container` are the new ansible-docker operation module names. Ported old ansible tasks from `docker` and shell scripts to `docker_image` and `docker_container`.