### PR TITLE
Copies beanstalkc for weekly scan in during provisioning

### DIFF
--- a/provisions/roles/jenkins/master/tasks/jobs.yml
+++ b/provisions/roles/jenkins/master/tasks/jobs.yml
@@ -41,6 +41,7 @@
     - ../jenkinsbuilder/cccp_index_reader.py
     - ../jenkinsbuilder/project-defaults.yml
     - ../jenkinsbuilder/weekly-scan.py
+    - ../container_pipeline/vendors/beanstalkc.py
   when: not vagrant
 
 - name: Replace Jenkins master with its FQDN for Weekly Scan job


### PR DESCRIPTION
  This change copies beanstalkc.py in jenkinsbuilder directory
  during provisioning. This was a bug and needed fix for weekly scan
  to run. weekly scan script was erroring out failing to import beanstalkc