### PR TITLE
Populate DB with image names before triggering build

### DIFF
--- a/ci/tests/test_01_functional/test_01_repo_monitoring/__init__.py
+++ b/ci/tests/test_01_functional/test_01_repo_monitoring/__init__.py
@@ -35,28 +35,6 @@ class TestRepoMonitoring(BaseTestCase):
             'cd /opt/cccp-service && '
             'python -c "{}"'.format(_script))
 
-    def test_00_if_fetch_scan_image_job_is_successful(self):
-        self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s http://localhost:8080 '
-            'enable-job fetch-scan-image')
-        print self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s http://localhost:8080 '
-            'build fetch-scan-image -f -v')
-        self.run_cmd(
-            'java -jar /opt/jenkins-cli.jar -s http://localhost:8080 '
-            'disable-job fetch-scan-image')
-        out = self.run_dj_script(
-                    'from container_pipeline.models.tracking import '
-                    'ContainerImage; '
-                    'print ContainerImage.objects.all().count()')
-        print 'Images fetched', out.strip()
-        self.assertTrue(int(out.strip()))
-        out = self.run_dj_script('from container_pipeline.models.tracking '
-                                 'import Package; '
-                                 'print Package.objects.all().count()')
-        print 'Packages found', out.strip()
-        self.assertTrue(int(out.strip()) > 0)
-
     def test_01_image_delivery_triggers_image_scan(self):
         # Create ContainerImage for bamachrn/python:release
         # In the real world, it will be created automatically by

--- a/provisions/roles/ci/tasks/ci.yml
+++ b/provisions/roles/ci/tasks/ci.yml
@@ -1,8 +1,4 @@
 ---
-- name: Disable fetch-scan-image job
-  shell: java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} disable-job fetch-scan-image
-  when: test
-
 - name: Enable cccp-index job
   shell: java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} enable-job cccp-index
   when: test

--- a/provisions/roles/jenkins/master/templates/index.yml.j2
+++ b/provisions/roles/jenkins/master/templates/index.yml.j2
@@ -16,6 +16,8 @@
             CWD=`pwd`
             cd /opt/cccp-service/jenkinsbuilder
             python cccp_index_reader.py $CWD/index.d
+            cd /opt/cccp-service/
+            python manage.py fetchimagelist $CWD/index.d
 
 - job:
     name: 'weekly-image-scan'

--- a/provisions/roles/repo_tracking/templates/jobs.yml.j2
+++ b/provisions/roles/repo_tracking/templates/jobs.yml.j2
@@ -10,27 +10,3 @@
             ./manage.py checkupdates
     triggers:
         - timed: "@midnight"
-
-- job:
-    name: 'fetch-scan-image'
-    description: |
-        Managed by Jenkins Job Builder, do not edit manually!
-    node: master
-    scm:
-        - git:
-            url: "{{ cccp_index_repo }}"
-            branches:
-                - "origin/master"
-            skip-tag: True
-    triggers:
-        - reverse:
-            jobs: "cccp-index"
-            result: 'success'
-        - pollscm: "H/10 * * * *"
-    builders:
-        - shell: |
-            export CWD=`pwd`
-            export DOCKER_HOST=localhost:2367
-            cd /opt/cccp-service/
-            python manage.py fetchimagelist $CWD/index.d
-            python manage.py imagescanner onetime


### PR DESCRIPTION
This is to ensure that when image_scanner worker checks for image name
in the DB, it's actually there.