### PR TITLE
deployment: systemd services reload and clean up tweaks

### DIFF
--- a/provisions/roles/cleanup/jenkins/master/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/master/tasks/main.yml
@@ -10,4 +10,4 @@
 - name: Remove images with no name or tag
   sudo: yes
   ignore_errors: yes
-  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"
+  shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/cleanup/jenkins/master/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/master/tasks/main.yml
@@ -2,3 +2,7 @@
 - name: Stop jenkins systemd service
   sudo: yes
   service: name=jenkins state=stopped
+
+- name: Remove the virtual environment directories
+  sudo: yes
+  file: path=/opt/cccp-service state=absent

--- a/provisions/roles/cleanup/jenkins/master/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/master/tasks/main.yml
@@ -6,3 +6,8 @@
 - name: Remove the virtual environment directories
   sudo: yes
   file: path=/opt/cccp-service state=absent
+
+- name: Remove images with no name or tag
+  sudo: yes
+  ignore_errors: yes
+  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"

--- a/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
@@ -14,3 +14,8 @@
 - name: Remove /opt/cccp-service directory
   sudo: yes
   file: path=/opt/cccp-service state=absent
+
+- name: Remove images with no name or tag
+  sudo: yes
+  ignore_errors: yes
+  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"

--- a/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
@@ -10,3 +10,7 @@
     - build-worker
     - test-worker
     - delivery-worker
+
+- name: Remove /opt/cccp-service directory
+  sudo: yes
+  file: path=/opt/cccp-service state=absent

--- a/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
@@ -18,4 +18,4 @@
 - name: Remove images with no name or tag
   sudo: yes
   ignore_errors: yes
-  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"
+  shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/cleanup/openshift/tasks/main.yml
+++ b/provisions/roles/cleanup/openshift/tasks/main.yml
@@ -17,3 +17,8 @@
 - name: Remove /var/lib/origin/* directory contents
   sudo: yes
   shell: rm -rf /var/lib/origin/*
+
+- name: Remove images with no name or tag
+  sudo: yes
+  ignore_errors: yes
+  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"

--- a/provisions/roles/cleanup/openshift/tasks/main.yml
+++ b/provisions/roles/cleanup/openshift/tasks/main.yml
@@ -21,4 +21,4 @@
 - name: Remove images with no name or tag
   sudo: yes
   ignore_errors: yes
-  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"
+  shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/cleanup/scanner/tasks/main.yml
+++ b/provisions/roles/cleanup/scanner/tasks/main.yml
@@ -10,3 +10,8 @@
 - name: Remove /var/lib/docker/volumes/* directory contents
   sudo: yes
   shell: rm -rf /var/lib/docker/volumes/*
+
+- name: Remove images with no name or tag
+  sudo: yes
+  ignore_errors: yes
+  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"

--- a/provisions/roles/cleanup/scanner/tasks/main.yml
+++ b/provisions/roles/cleanup/scanner/tasks/main.yml
@@ -14,4 +14,4 @@
 - name: Remove images with no name or tag
   sudo: yes
   ignore_errors: yes
-  shell: "docker rmi -f $(docker images | awk '/<none>/ {print $3}')"
+  shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/jenkins/master/tasks/install.yml
+++ b/provisions/roles/jenkins/master/tasks/install.yml
@@ -17,7 +17,7 @@
 
 - name: Reload jenkins systemd service
   sudo: yes
-  service: name=jenkins state=reloaded
+  systemd: name=jenkins state=reloaded
 
 - name: Ensure jenkins is enabled and started
-  service: name=jenkins state=started enabled=yes
+  systemd: name=jenkins state=started enabled=yes

--- a/provisions/roles/jenkins/master/tasks/install.yml
+++ b/provisions/roles/jenkins/master/tasks/install.yml
@@ -15,5 +15,9 @@
 - name: Ensure Jenkins is installed.
   yum: name=jenkins-2.67-1.1 state=present
 
+- name: Reload jenkins systemd service
+  sudo: yes
+  service: name=jenkins state=reloaded
+
 - name: Ensure jenkins is enabled and started
   service: name=jenkins state=started enabled=yes

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -13,10 +13,10 @@
 
 - name: Reload docker systemd service
   sudo: yes
-  service: name=docker state=reloaded
+  systemd: name=docker state=reloaded
 
 - name: Restart Docker
-  service: name=docker state=restarted enabled=yes
+  systemd: name=docker state=restarted enabled=yes
 
 - name: Build container-pipeline image
   sudo: yes
@@ -98,11 +98,11 @@
 
 - name: Reload Dockerfile linter worker systemd service
   sudo: yes
-  service: name=cccp-dockerfile-lint-worker state=reloaded
+  systemd: name=cccp-dockerfile-lint-worker state=reloaded
   tags:
       - application
 
 - name: Enable and start Dockerfile linter worker
-  service: name=cccp-dockerfile-lint-worker enabled=yes state=restarted
+  systemd: name=cccp-dockerfile-lint-worker enabled=yes state=restarted
   tags:
       - application

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -11,6 +11,10 @@
     regexp="^#?\s*ADD_REGISTRY=.*"
     replace='ADD_REGISTRY="--add-registry {{ public_registry }}:5000 --add-registry registry.centos.org"'
 
+- name: Reload docker systemd service
+  sudo: yes
+  service: name=docker state=reloaded
+
 - name: Restart Docker
   service: name=docker state=restarted enabled=yes
 
@@ -89,6 +93,12 @@
   copy:
       src: ../../scripts/cccp-dockerfile-lint-worker.service
       dest: /etc/systemd/system/cccp-dockerfile-lint-worker.service
+  tags:
+      - application
+
+- name: Reload Dockerfile linter worker systemd service
+  sudo: yes
+  service: name=cccp-dockerfile-lint-worker state=reloaded
   tags:
       - application
 

--- a/provisions/roles/nginx/tasks/main.yml
+++ b/provisions/roles/nginx/tasks/main.yml
@@ -33,6 +33,13 @@
       - nginx
       - jenkins/slave
 
+  - name: Reload nginx systemd service
+    sudo: yes
+    service: name=nginx state=reloaded
+    tags:
+      - nginx
+      - jenkins/slave
+
   - name: restart nginx
     sudo: yes
     service: name=nginx state=restarted enabled=yes

--- a/provisions/roles/nginx/tasks/main.yml
+++ b/provisions/roles/nginx/tasks/main.yml
@@ -35,7 +35,7 @@
 
   - name: Reload nginx systemd service
     sudo: yes
-    service: name=nginx state=reloaded
+    systemd: name=nginx state=reloaded
     tags:
       - nginx
       - jenkins/slave

--- a/provisions/roles/openshift/tasks/install.yml
+++ b/provisions/roles/openshift/tasks/install.yml
@@ -17,10 +17,10 @@
 
 - name: Reload docker systemd service
   sudo: yes
-  service: name=docker state=reloaded
+  systemd: name=docker state=reloaded
 
 - name: Start Docker service
-  service: name=docker state=started enabled=yes
+  systemd: name=docker state=started enabled=yes
 
 - name: Start beanstalkd service
-  service: name=beanstalkd state=started enabled=yes
+  systemd: name=beanstalkd state=started enabled=yes

--- a/provisions/roles/openshift/tasks/install.yml
+++ b/provisions/roles/openshift/tasks/install.yml
@@ -15,6 +15,10 @@
       - docker
       - python-docker-py
 
+- name: Reload docker systemd service
+  sudo: yes
+  service: name=docker state=reloaded
+
 - name: Start Docker service
   service: name=docker state=started enabled=yes
 

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -107,7 +107,11 @@
       command: sh /install.sh
       state: started
 
-- name: Get service files for workers
+- name: Ensure log path exists
+  file: path=/srv/pipeline-logs/cccp.log state=touch
+  tags: scanner
+
+- name: Get service file for scan worker
   copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -117,16 +121,15 @@
       - scanner
       - application
 
-- name: Ensure log path exists
-  file: path=/srv/pipeline-logs/cccp.log state=touch
-  tags: scanner
+- name: Reload scan worker systemd service
+  sudo: yes
+  service: name=cccp-scan-worker state=reloaded
+  tags:
+      - scanner
+      - application
 
-- name: Enable Scanner worker
-  service: name="cccp-scan-worker" state=restarted enabled=yes
-  tags: scanner
-
-- name: Restart Scanner worker service
-  service: name="cccp-scan-worker" state=restarted enabled=yes
+- name: Restart scan  worker systemd service
+  service: name=cccp-scan-worker state=restarted enabled=yes
   tags:
       - scanner
       - application

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -32,7 +32,7 @@
   tags: scanner
 
 - name: Start and Enable docker
-  service: name=docker enabled=yes state=started
+  systemd: name=docker enabled=yes state=started
   sudo: yes
   tags: scanner
 
@@ -57,7 +57,7 @@
   tags: scanner
 
 - name: Restart Docker
-  service: name=docker state=restarted enabled=yes
+  systemd: name=docker state=restarted enabled=yes
   tags: scanner
 
 - name: Install pipeline-scanner container
@@ -123,13 +123,13 @@
 
 - name: Reload scan worker systemd service
   sudo: yes
-  service: name=cccp-scan-worker state=reloaded
+  systemd: name=cccp-scan-worker state=reloaded
   tags:
       - scanner
       - application
 
 - name: Restart scan  worker systemd service
-  service: name=cccp-scan-worker state=restarted enabled=yes
+  systemd: name=cccp-scan-worker state=restarted enabled=yes
   tags:
       - scanner
       - application


### PR DESCRIPTION
  This PR aims to improve the service deployment via ansible.


  - Reloads all the cccp-service systemd services before
  restarting them during deployment.

  - Improves clean up module to remove stale code while ran clean up module before deployment