### PR TITLE
Fixes reload operation for scanner and lint worker

### DIFF
--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -95,11 +95,11 @@
   tags:
       - application
 
-  #- name: Reload Dockerfile linter worker systemd service
-  # sudo: yes
-  # systemd: name=cccp-dockerfile-lint-worker state=reloaded
-  # tags:
-  #    - application
+- name: Reload Dockerfile linter worker systemd service
+  sudo: yes
+  systemd: name=cccp-dockerfile-lint-worker daemon_reload=yes
+  tags:
+      - application
 
 - name: Enable and start Dockerfile linter worker
   systemd: name=cccp-dockerfile-lint-worker enabled=yes state=restarted

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -95,11 +95,11 @@
   tags:
       - application
 
-- name: Reload Dockerfile linter worker systemd service
-  sudo: yes
-  systemd: name=cccp-dockerfile-lint-worker state=reloaded
-  tags:
-      - application
+  #- name: Reload Dockerfile linter worker systemd service
+  # sudo: yes
+  # systemd: name=cccp-dockerfile-lint-worker state=reloaded
+  # tags:
+  #    - application
 
 - name: Enable and start Dockerfile linter worker
   systemd: name=cccp-dockerfile-lint-worker enabled=yes state=restarted

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -119,13 +119,12 @@
   tags:
       - scanner
       - application
-
-  # - name: Reload scan worker systemd service
-  # sudo: yes
-  # systemd: name=cccp-scan-worker state=reloaded
-  # tags:
-  #     - scanner
-  #    - application
+- name: Reload scan worker systemd service
+  sudo: yes
+  systemd: name=cccp-scan-worker daemon_reload=yes
+  tags:
+      - scanner
+      - application
 
 - name: Restart scan  worker systemd service
   systemd: name=cccp-scan-worker state=restarted enabled=yes

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -120,12 +120,12 @@
       - scanner
       - application
 
-- name: Reload scan worker systemd service
-  sudo: yes
-  systemd: name=cccp-scan-worker state=reloaded
-  tags:
-      - scanner
-      - application
+  # - name: Reload scan worker systemd service
+  # sudo: yes
+  # systemd: name=cccp-scan-worker state=reloaded
+  # tags:
+  #     - scanner
+  #    - application
 
 - name: Restart scan  worker systemd service
   systemd: name=cccp-scan-worker state=restarted enabled=yes


### PR DESCRIPTION
  Removes reload operations for scanner and lint worker since
  both services' unit files do not support reload operations.