### PR TITLE
Refactor openshift logs retirval and project deletion

### DIFF
--- a/Dockerfile.mailserv
+++ b/Dockerfile.mailserv
@@ -18,6 +18,6 @@ ADD mail_service /opt/cccp-service/mail_service/
 RUN chmod 777 /opt/cccp-service/mail_service/*
 
 ENV PYTHONPATH=$PYTHONPATH:/opt/cccp-service/
-WORKDIR /opt/cccp-service
+WORKDIR /opt/cccp-service/mail_service
 
 CMD ["/opt/cccp-service/mail_service/start_mail_server.sh"]

--- a/Dockerfile.mailserv
+++ b/Dockerfile.mailserv
@@ -12,6 +12,10 @@ RUN yum update -y && \
 RUN pip install raven --upgrade
 
 RUN mkdir -p /opt/cccp-service
+
+ADD oc /usr/bin/oc
+ADD node.kubeconfig ca.crt /opt/cccp-service/
+
 ADD container_pipeline /opt/cccp-service/container_pipeline
 ADD mail_service /opt/cccp-service/mail_service/
 

--- a/container_pipeline/lib/openshift.py
+++ b/container_pipeline/lib/openshift.py
@@ -19,9 +19,12 @@ class Openshift(object):
         self.password = password or settings.OPENSHIFT_PASSWORD
         self.config = config or settings.OC_CONFIG
         self.cert = cert or settings.OC_CERT
-        self.oc_cmd_suffix = (
+        self.oc_login_suffix = (
             '--config {config} --certificate-authority {cert}'.format(
                 config=self.config, cert=self.cert))
+        self.oc_cmd_suffix = (
+            '--config {config}'.format(
+                config=self.config))
         self.logger = logger or logging.getLogger('console')
 
     def login(self, user=None, password=None):
@@ -35,7 +38,7 @@ class Openshift(object):
                         'oc login {endpoint} -u {user} -p {password} {suffix}'
                         .format(
                             endpoint=self.endpoint, user=user,
-                            password=password, suffix=self.oc_cmd_suffix
+                            password=password, suffix=self.oc_login_suffix
                         ))
                 )
             )

--- a/mail_service/worker_notify_user.py
+++ b/mail_service/worker_notify_user.py
@@ -74,7 +74,7 @@ class NotifyUser(object):
 
     def __init__(self, job_info):
 
-        self.send_mail_command = "/mail_service/send_mail.sh"
+        self.send_mail_command = "/opt/cccp-service/mail_service/send_mail.sh"
         self.job_info = job_info
 
         # the logs directory

--- a/provisions/main.yml
+++ b/provisions/main.yml
@@ -46,13 +46,6 @@
   tags:
     - jenkins
 
-- name: Setup openshift
-  hosts: openshift
-  roles:
-    - openshift
-  tags:
-    - openshift
-
 - name: Generate source code config file
   hosts: jenkins_slaves
   tasks:
@@ -97,6 +90,13 @@
   tags:
       - application
       - application/update_src
+
+- name: Setup openshift
+  hosts: openshift
+  roles:
+    - openshift
+  tags:
+    - openshift
 
 - name: Setup Scanner Worker
   hosts: scanner_worker

--- a/provisions/roles/openshift/tasks/setup.yml
+++ b/provisions/roles/openshift/tasks/setup.yml
@@ -37,28 +37,12 @@
     KUBECONFIG: "{{ kubeconfig }}"
   ignore_errors: yes
 
-- name: Get cccp service code
-  synchronize:
-    src: "{{ role_path }}/../../../"
-    dest: "{{ ansible_env.HOME }}/cccp-service"
-    mode: push
-    rsync_opts:
-      - "{{ rsync_ssh_opts }}"
-
-- name: Build cccp build image
+- name: Build cccp builder images
   docker_image:
-    path: "{{ ansible_env.HOME }}/cccp-service/server"
-    name: cccp-build
-    dockerfile: Dockerfile.build
-
-- name: Build cccp test image
-  docker_image:
-    path: "{{ ansible_env.HOME }}/cccp-service/server"
-    name: cccp-test
-    dockerfile: Dockerfile.test
-
-- name: Build cccp delivery image
-  docker_image:
-    path: "{{ ansible_env.HOME }}/cccp-service/server"
-    name: cccp-delivery
-    dockerfile: Dockerfile.delivery
+    path: /opt/cccp-service/server
+    name: "{{ item.image_name }}"
+    dockerfile: "{{ item.file_name }}"
+  with_items:
+    - {image_name: cccp-build, file_name: Dockerfile.build}
+    - {image_name: cccp-test, file_name: Dockerfile.test}
+    - {image_name: cccp-delivery, file_name: Dockerfile.delivery}

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -4,6 +4,7 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     remote_src: yes
+    mode: 0777
   with_items:
     - {src: /usr/bin/oc, dest: "{{ ansible_env.HOME }}/cccp-service/oc"}
     - {src: /var/lib/origin/openshift.local.config/master/ca.crt, dest: "{{ ansible_env.HOME }}/cccp-service/ca.crt"}

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -6,9 +6,9 @@
     remote_src: yes
     mode: 0777
   with_items:
-    - {src: /usr/bin/oc, dest: "{{ ansible_env.HOME }}/cccp-service/oc"}
-    - {src: /var/lib/origin/openshift.local.config/master/ca.crt, dest: "{{ ansible_env.HOME }}/cccp-service/ca.crt"}
-    - {src: /var/lib/origin/openshift.local.config/master/admin.kubeconfig,dest: "{{ ansible_env.HOME }}/cccp-service/node.kubeconfig"}
+    - {src: /usr/bin/oc, dest: "/opt/cccp-service/oc"}
+    - {src: /var/lib/origin/openshift.local.config/master/ca.crt, dest: "/opt/cccp-service/ca.crt"}
+    - {src: /var/lib/origin/openshift.local.config/master/admin.kubeconfig, dest: "/opt/cccp-service/node.kubeconfig"}
 
 - name: Ensure log path exists
   file: path=/srv/pipeline-logs/cccp.log state=touch
@@ -23,7 +23,7 @@
 
 - name: Set log level
   replace: >
-      dest="{{ ansible_env.HOME }}/cccp-service/mail_service/config.py"
+      dest="/opt/cccp-service/mail_service/config.py"
       regexp="LOG_LEVEL =.*"
       replace="LOG_LEVEL = '{{ log_level }}'"
 
@@ -31,7 +31,7 @@
   sudo: yes
   docker_image:
     name: mail-server
-    path: "{{ ansible_env.HOME }}/cccp-service"
+    path: "/opt/cccp-service"
     dockerfile: Dockerfile.mailserv
 
 - name: Start Mail Service

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -1,4 +1,13 @@
 ---
+- name: Pull oc files from openshift
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    remote_src: yes
+  with_items:
+    - {src: /usr/bin/oc, dest: /opt/cccp-service/oc}
+    - {src: /var/lib/origin/openshift.local.config/master/ca.crt, dest: /opt/cccp-service/ca.crt}
+    - {src: /var/lib/origin/openshift.local.config/master/admin.kubeconfig,dest: /opt/cccp-service/node.kubeconfig}
 
 - name: Ensure log path exists
   file: path=/srv/pipeline-logs/cccp.log state=touch

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -5,9 +5,9 @@
     dest: "{{ item.dest }}"
     remote_src: yes
   with_items:
-    - {src: /usr/bin/oc, dest: /opt/cccp-service/oc}
-    - {src: /var/lib/origin/openshift.local.config/master/ca.crt, dest: /opt/cccp-service/ca.crt}
-    - {src: /var/lib/origin/openshift.local.config/master/admin.kubeconfig,dest: /opt/cccp-service/node.kubeconfig}
+    - {src: /usr/bin/oc, dest: "{{ ansible_env.HOME }}/cccp-service/oc"}
+    - {src: /var/lib/origin/openshift.local.config/master/ca.crt, dest: "{{ ansible_env.HOME }}/cccp-service/ca.crt"}
+    - {src: /var/lib/origin/openshift.local.config/master/admin.kubeconfig,dest: "{{ ansible_env.HOME }}/cccp-service/node.kubeconfig"}
 
 - name: Ensure log path exists
   file: path=/srv/pipeline-logs/cccp.log state=touch


### PR DESCRIPTION
We have changed the service flow to delete the openshift project after we send the mail to user. This is to make sure we are cleaning up the openshit project even if the build fails, after we collect all the logs for notification.
This PR fixes below things
* send_mail  script path for sending mail with proper from id
* re-factored the provision flow to use same place  in all the machines to store code base
* fixes openshift logs retrieval error due to extra parameters passed
* project deletion after the mail is sent to user