### PR TITLE
Stop setting action to <worker>_failure when a worker fails

### DIFF
--- a/container_pipeline/pipeline.py
+++ b/container_pipeline/pipeline.py
@@ -51,6 +51,9 @@ def create_new_job():
         "target_file",   # Name of the Dockerfile to use to build container
                          # image
         "test_tag",      # temporary tag to be applied to image
+        "msg",           # to capture message in case of exception in
+                         # triggering linter
+        "delivery_log_file",     # log file for delivery worker
     ])
 
     return job

--- a/container_pipeline/trigger_dockerfile_lint.py
+++ b/container_pipeline/trigger_dockerfile_lint.py
@@ -26,40 +26,48 @@ def trigger_dockerfile_linter(job):
         print "==> Error opening the file %s" % dockerfile_location
         print "==> Error: %s" % str(e)
         print "==> Sending Dockerfile linter failure email"
-        response = {
-            "action": "notify_user",
-            "namespace": job["appid"],
-            "notify_email": job["notify_email"],
-            "job_name": job["job_name"],
-            "msg": "Couldn't find the Dockerfile at specified git_path",
-            "logs_dir": job["logs_dir"],
-            "lint_status": False,
-            "build_status": False,
-            "project_name": job["project_name"],
-            "test_tag": job["test_tag"]
-        }
+        # response = {
+        #     "action": "notify_user",
+        #     "namespace": job["appid"],
+        #     "notify_email": job["notify_email"],
+        #     "job_name": job["job_name"],
+        #     "msg": "Couldn't find the Dockerfile at specified git_path",
+        #     "logs_dir": job["logs_dir"],
+        #     "lint_status": False,
+        #     "build_status": False,
+        #     "project_name": job["project_name"],
+        #     "test_tag": job["test_tag"]
+        # }
+        job["action"] = "notify_user"
+        job["lint_status"] = False
+        job["build_status"] = False
+        job["msg"] = "Couldn't find the Dockerfile at specified git_path"
 
-        queue.put(json.dumps(response), tube="master_tube")
+        queue.put(json.dumps(job), tube="master_tube")
         print "==>Put job on 'master_tube' tube"
         return False
     except BaseException as e:
         print "==> Encountered unexpected error. Dockerfile lint trigger failed"
         print "==> Error: %s" % str(e)
         print "==> Sending Dockerfile linter failure email"
-        response = {
-            "action": "notify_user",
-            "namespace": job["appid"],
-            "notify_email": job["notify_email"],
-            "job_name": job["job_name"],
-            "msg": "Unexpected error while trigger Dockerfile linter",
-            "logs_dir": job["logs_dir"],
-            "lint_status": False,
-            "build_status": False,
-            "project_name": job["project_name"],
-            "test_tag": job["test_tag"]
-        }
+        # response = {
+        #     "action": "notify_user",
+        #     "namespace": job["appid"],
+        #     "notify_email": job["notify_email"],
+        #     "job_name": job["job_name"],
+        #     "msg": "Unexpected error while trigger Dockerfile linter",
+        #     "logs_dir": job["logs_dir"],
+        #     "lint_status": False,
+        #     "build_status": False,
+        #     "project_name": job["project_name"],
+        #     "test_tag": job["test_tag"]
+        # }
+        job["action"] = "notify_user"
+        job["lint_status"] = False
+        job["build_status"] = False
+        job["msg"] = "Unexpected error while trigger Dockerfile linter"
 
-        queue.put(json.dumps(response), tube="master_tube")
+        queue.put(json.dumps(job), tube="master_tube")
         print "==>Put job on 'master_tube' tube"
         return False
     else:

--- a/container_pipeline/workers/build.py
+++ b/container_pipeline/workers/build.py
@@ -99,22 +99,21 @@ class BuildWorker(BaseWorker):
 
     def handle_build_failure(self):
         """Handle build failure for job"""
-        self.job['action'] = "build_failure"
+        self.job['action'] = "notify_user"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(
-            "Build is not successful putting it to failed build tube")
-        data = {
-            'action': 'notify_user',
-            'namespace': self.job["namespace"],
-            'build_status': False,
-            'notify_email': self.job['notify_email'],
-            'build_logs_file': os.path.join(
-                self.job['logs_dir'], 'build_logs.txt'),
-            'logs_dir': self.job['logs_dir'],
-            'project_name': self.job['project_name'],
-            'job_name': self.job['job_name'],
-            'test_tag': self.job['test_tag']}
-        self.notify(data)
+            "Build is not successful. Notifying the user.")
+        # data = {
+        #     'action': 'notify_user',
+        #     'namespace': self.job["namespace"],
+        #     'build_status': False,
+        #     'notify_email': self.job['notify_email'],
+        #     'build_logs_file': os.path.join(
+        #         self.job['logs_dir'], 'build_logs.txt'),
+        #     'logs_dir': self.job['logs_dir'],
+        #     'project_name': self.job['project_name'],
+        #     'job_name': self.job['job_name'],
+        #     'test_tag': self.job['test_tag']}
 
 
 if __name__ == '__main__':

--- a/container_pipeline/workers/build.py
+++ b/container_pipeline/workers/build.py
@@ -99,7 +99,6 @@ class BuildWorker(BaseWorker):
 
     def handle_build_failure(self):
         """Handle build failure for job"""
-        self.job.pop('action', None)
         self.job['action'] = "build_failure"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(

--- a/container_pipeline/workers/delivery.py
+++ b/container_pipeline/workers/delivery.py
@@ -92,7 +92,6 @@ class DeliveryWorker(BaseWorker):
         Puts the job back to the delivery tube for later attempt at delivery
         and requests to notify the user about failure to deliver
         """
-        self.job.pop('action', None)
         self.job['action'] = "notify_user"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(

--- a/container_pipeline/workers/delivery.py
+++ b/container_pipeline/workers/delivery.py
@@ -75,7 +75,6 @@ class DeliveryWorker(BaseWorker):
             self.job['namespace']))
         self.logger.debug('Putting job details to master_tube for tracker\'s'
                           ' consumption')
-        project_hash_key = self.job["project_hash_key"]
 
         # sending notification as delivery complete and also addingn this into
         # tracker.
@@ -94,22 +93,22 @@ class DeliveryWorker(BaseWorker):
         and requests to notify the user about failure to deliver
         """
         self.job.pop('action', None)
-        self.job['action'] = "delivery_failure"
+        self.job['action'] = "notify_user"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(
-            "Delivery is not successful putting it to failed delivery tube")
-        data = {
-            'action': 'notify_user',
-            'namespace': self.job["namespace"],
-            'build_status': False,
-            'notify_email': self.job['notify_email'],
-            'delivery_logs_file': os.path.join(
-                self.job['logs_dir'], 'delivery_logs.txt'),
-            'logs_dir': self.job['logs_dir'],
-            'project_name': self.job["project_name"],
-            'job_name': self.job['jobid'],
-            'test_tag': self.job['test_tag']}
-        self.notify(data)
+            "Delivery is not successful. Notifying the user.")
+        # data = {
+        #     'action': 'notify_user',
+        #     'namespace': self.job["namespace"],
+        #     'build_status': False,
+        #     'notify_email': self.job['notify_email'],
+        #     'delivery_logs_file': os.path.join(
+        #         self.job['logs_dir'], 'delivery_logs.txt'),
+        #     'logs_dir': self.job['logs_dir'],
+        #     'project_name': self.job["project_name"],
+        #     'job_name': self.job['jobid'],
+        #     'test_tag': self.job['test_tag']}
+        # self.notify(data)
 
 
 if __name__ == "__main__":

--- a/container_pipeline/workers/test.py
+++ b/container_pipeline/workers/test.py
@@ -55,22 +55,22 @@ class TestWorker(BaseWorker):
 
     def handle_test_failure(self):
         """Handle test failure for job"""
-        self.job['action'] = "test_failure"
+        self.job['action'] = "notify_user"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(
-            "Test is not successful putting it to failed build tube")
-        data = {
-            'action': 'notify_user',
-            'namespace': self.job["namespace"],
-            'build_status': False,
-            'notify_email': self.job['notify_email'],
-            'test_logs_file': os.path.join(
-                self.job['logs_dir'], 'test_logs.txt'),
-            'project_name': self.job["project_name"],
-            'job_name': self.job['jobid'],
-            'test_tag': self.job['test_tag']}
-        self.logger.debug('Notify test failure: {}'.format(data))
-        self.notify(data)
+            "Test is not successful. Notifying the user.")
+        # data = {
+        #     'action': 'notify_user',
+        #     'namespace': self.job["namespace"],
+        #     'build_status': False,
+        #     'notify_email': self.job['notify_email'],
+        #     'test_logs_file': os.path.join(
+        #         self.job['logs_dir'], 'test_logs.txt'),
+        #     'project_name': self.job["project_name"],
+        #     'job_name': self.job['jobid'],
+        #     'test_tag': self.job['test_tag']}
+        # self.logger.debug('Notify test failure: {}'.format(data))
+        # self.notify(data)
 
     def handle_job(self, job):
         """This runs the test worker"""


### PR DESCRIPTION
Linter and delivery worker had some anomalies in that they used a different version of `job` data that was being put to the beanstalkd tube. This PR fixes it by making sure that these workers use global job data created in `pipeline.py` at the beginning of the lint-build-test-scan-deliver process.