### PR TITLE
Set build_status to false if test or delivery phase fails

### DIFF
--- a/container_pipeline/workers/delivery.py
+++ b/container_pipeline/workers/delivery.py
@@ -33,7 +33,6 @@ class DeliveryWorker(BaseWorker):
         if success:
             self.handle_delivery_success()
         else:
-            self.job["build_status"] = False
             self.handle_delivery_failure()
 
     def deliver_build(self):
@@ -93,6 +92,7 @@ class DeliveryWorker(BaseWorker):
         Puts the job back to the delivery tube for later attempt at delivery
         and requests to notify the user about failure to deliver
         """
+        self.job["build_status"] = False
         self.job['action'] = "notify_user"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(

--- a/container_pipeline/workers/delivery.py
+++ b/container_pipeline/workers/delivery.py
@@ -33,6 +33,7 @@ class DeliveryWorker(BaseWorker):
         if success:
             self.handle_delivery_success()
         else:
+            self.job["build_status"] = False
             self.handle_delivery_failure()
 
     def deliver_build(self):

--- a/container_pipeline/workers/test.py
+++ b/container_pipeline/workers/test.py
@@ -80,6 +80,7 @@ class TestWorker(BaseWorker):
         if success:
             self.handle_test_success()
         else:
+            self.job["build_status"] = False
             self.handle_test_failure()
 
 

--- a/container_pipeline/workers/test.py
+++ b/container_pipeline/workers/test.py
@@ -55,6 +55,7 @@ class TestWorker(BaseWorker):
 
     def handle_test_failure(self):
         """Handle test failure for job"""
+        self.job["build_status"] = False
         self.job['action'] = "notify_user"
         self.queue.put(json.dumps(self.job), 'master_tube')
         self.logger.warning(
@@ -80,7 +81,6 @@ class TestWorker(BaseWorker):
         if success:
             self.handle_test_success()
         else:
-            self.job["build_status"] = False
             self.handle_test_failure()
 
 


### PR DESCRIPTION
We decided to have a status flag for every phase. So, lint -> `lint_status`, build -> `build_status`, so on and so forth. But at the moment, mail server worker doesn't have a classification among these. So if build, test or delivery phases fail, we set `build_status` to fail to inform the user that build has failed and image won't be available on registry.centos.org.

There's already a card on OSIO about refactoring mail worker that @bamachrn is looking into.