### PR TITLE
Fixes phase name while logging error message in log file

### DIFF
--- a/container_pipeline/lib/openshift.py
+++ b/container_pipeline/lib/openshift.py
@@ -192,7 +192,7 @@ class Openshift(object):
                 empty_retry_count = 0
             time.sleep(retry_delay)
 
-    def get_build_logs(self, project, build_id):
+    def get_build_logs(self, project, build_id, build_type="build"):
         try:
             output = run_cmd(
                 'oc logs --namespace {project} build/{build_id} {suffix}'
@@ -203,9 +203,9 @@ class Openshift(object):
                 project, build_id, output))
         except subprocess.CalledProcessError as e:
             self.logger.error(
-                'Could not retrieve build logs for project build: '
-                '{}/{}\n{}'.format(project, build_id, e))
-            output = 'Could not retrieve build logs'
+                'Could not retrieve {} phase logs for project build: '
+                '{}/{}\n{}'.format(build_type, project, build_id, e))
+            output = 'Could not retrieve %s phase logs.' % build_type
         return output
 
     def delete_pods(self, project, build_id):

--- a/container_pipeline/workers/delivery.py
+++ b/container_pipeline/workers/delivery.py
@@ -57,7 +57,8 @@ class DeliveryWorker(BaseWorker):
 
         delivery_status = self.openshift.wait_for_build_status(
             project_hash_key, delivery_id, 'Complete', status_index=2)
-        logs = self.openshift.get_build_logs(project_hash_key, delivery_id)
+        logs = self.openshift.get_build_logs(
+                project_hash_key, delivery_id, "delivery")
         delivery_logs_file = os.path.join(
             self.job['logs_dir'], 'delivery_logs.txt')
         self.export_logs(logs, delivery_logs_file)

--- a/container_pipeline/workers/test.py
+++ b/container_pipeline/workers/test.py
@@ -42,7 +42,7 @@ class TestWorker(BaseWorker):
         Build(namespace).start()
         test_status = self.openshift.wait_for_build_status(
             project, build_id, 'Complete', status_index=2)
-        logs = self.openshift.get_build_logs(project, build_id)
+        logs = self.openshift.get_build_logs(project, build_id, "test")
         test_logs_file = os.path.join(self.job['logs_dir'], 'test_logs.txt')
         self.export_logs(logs, test_logs_file)
         return test_status


### PR DESCRIPTION
  This changeset fixes openshift logs retrieval method to log proper phase
  name while there is an issue retrieval of logs. Earlier, if delivery phase
  logs retrieval fails, it will log "build" as phase name. With this fix,
  build, delivery and test phase names are given to log right phase names.