### PR TITLE
Modify database entry when entry in container-index changes

### DIFF
--- a/container_pipeline/management/commands/delete_stale_images.py
+++ b/container_pipeline/management/commands/delete_stale_images.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand  # CommandError
+from container_pipeline.models.tracking import ContainerImage
+import logging
+
+from jenkinsbuilder import cccp_index_reader as cir
+
+
+logger = logging.getLogger('tracking')
+
+
+class Command(BaseCommand):
+    help = 'Delete stale images from database'
+
+    def handle(self, *args, **options):
+        logger.info("Checking for stale projects")
+        indexd_path = args[0]
+
+        old_projects = cir.get_old_project_list()
+        new_projects = cir.get_new_project_list(indexd_path)
+
+        stale_projects = cir.find_stale_projects(old_projects, new_projects)
+
+        for project in stale_projects:
+            try:
+                container_image = ContainerImage.objects.get(name=project)
+                container_image.delete()
+            except Exception as e:
+                logger.critical("Error deleting image {}".format(container_image))
+                logger.error(e)

--- a/container_pipeline/management/commands/delete_stale_images.py
+++ b/container_pipeline/management/commands/delete_stale_images.py
@@ -19,6 +19,7 @@ class Command(BaseCommand):
         new_projects = cir.get_new_project_list(indexd_path)
 
         stale_projects = cir.find_stale_projects(old_projects, new_projects)
+        logger.info("List of stale projects: %s ", str(stale_projects))
 
         for project in stale_projects:
             try:

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -29,6 +29,8 @@ from glob import glob
 
 jjb_defaults_file = 'project-defaults.yml'
 
+logger = logging.getLogger('jenkins')
+
 # pathname of file having all project names
 # this file will be generated after first run
 # and will reside in same directory as of this python file
@@ -314,5 +316,4 @@ def main(indexdlocation):
 
 if __name__ == '__main__':
     load_logger()
-    logger = logging.getLogger('jenkins')
     main(sys.argv[1])

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -199,6 +199,21 @@ def get_new_project_list(indexdlocation):
     """
     new_projects_names = []
     for project in get_projects_from_index(indexdlocation):
+        new_projects_names.append(
+            str(project[0]["project"]["appid"]) + "/" +
+            str(project[0]["project"]["jobid"]) + ":" +
+            str(project[0]["project"]["desired_tag"])
+        )
+    return new_projects_names
+
+
+def create_or_update_project_on_jenkins(indexdlocation):
+    """
+    This function creates new project(s) on Jenkins if it finds new entry added
+    to container-index. It requires a path to the directory container
+    container-index.
+    """
+    for project in get_projects_from_index(indexdlocation):
         try:
             t = tempfile.mkdtemp()
             generated_filename = os.path.join(
@@ -226,11 +241,6 @@ def get_new_project_list(indexdlocation):
                 logger.critical("Project details: %s ", str(project))
                 exit(1)
 
-            new_projects_names.append(
-                str(project[0]["project"]["appid"]) + "/" +
-                str(project[0]["project"]["jobid"]) + ":" +
-                str(project[0]["project"]["desired_tag"])
-            )
         except Exception as e:
             logger.critical("Error updating jenkins job via file %s",
                             generated_filename)
@@ -239,7 +249,6 @@ def get_new_project_list(indexdlocation):
             # if jenkins job update fails, the cccp-index job should fail
             logger.critical(sys.exc_info()[0])
             raise
-    return new_projects_names
 
 
 def find_stale_projects(old, new):
@@ -282,6 +291,7 @@ def run_command(command):
 
 def main(indexdlocation):
     new_projects_names = get_new_project_list(indexdlocation)
+    create_or_update_project_on_jenkins(indexdlocation)
 
     # get list of old projects
     old_projects = get_old_project_list()

--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -227,8 +227,8 @@ def get_new_project_list(indexdlocation):
                 exit(1)
 
             new_projects_names.append(
-                str(project[0]["project"]["appid"]) + "-" +
-                str(project[0]["project"]["jobid"]) + "-" +
+                str(project[0]["project"]["appid"]) + "/" +
+                str(project[0]["project"]["jobid"]) + ":" +
                 str(project[0]["project"]["desired_tag"])
             )
         except Exception as e:
@@ -257,6 +257,7 @@ def delete_stale_projects_on_jenkins(stale_projects):
     bypasses by printing the error.
     """
     for project in stale_projects:
+        project = project.replace('/', '-').replace(':', '-')
         myargs = ["jenkins-jobs", "delete", project]
         # print either output or error
         _, error = run_command(myargs)

--- a/provisions/roles/jenkins/master/templates/index.yml.j2
+++ b/provisions/roles/jenkins/master/templates/index.yml.j2
@@ -15,6 +15,8 @@
         - shell: |
             CWD=`pwd`
             export PYTHONPATH="/opt/cccp-service"
+            cd /opt/cccp-service
+            python manage.py delete_stale_images $CWD/index.d
             cd /opt/cccp-service/jenkinsbuilder
             python cccp_index_reader.py $CWD/index.d
             cd /opt/cccp-service/


### PR DESCRIPTION
This PR ensures that when an entry is deleted or modified in container-index, the underlying entry in repo tracking database is deleted. In case of modification to container-index (eg: change in value of `desired_tag`), it deletes the old entry and creates new one.