### PR TITLE
Add scan summary in the output generated by scanners

### DIFF
--- a/atomic_scanners/container-capabilities-scanner/scanner.py
+++ b/atomic_scanners/container-capabilities-scanner/scanner.py
@@ -81,7 +81,7 @@ def template_json_data():
         # "Docker run command": "docker run -d {} tailf /dev/null".format(
         #     IMAGE_NAME),
         "Reference documentation": "http://www.projectatomic.io/blog/2016/01/how-to-run-a-more-secure-non-root-user-container/",
-        "Summary": None
+        "Summary": ""
     }
     return json_out
 

--- a/atomic_scanners/container-capabilities-scanner/scanner.py
+++ b/atomic_scanners/container-capabilities-scanner/scanner.py
@@ -53,7 +53,7 @@ def check_image_for_run_label(image):
     run_label = run_object.get_label("RUN")
 
     if run_label == "":
-        raise RunLabelException("Image doesn't have a RUN label")
+        raise RunLabelException("Dockerfile for the image doesn't have RUN label")
     return run_label
 
 
@@ -80,9 +80,11 @@ def template_json_data():
         "Scan Results": {"Container capabilities": None},
         # "Docker run command": "docker run -d {} tailf /dev/null".format(
         #     IMAGE_NAME),
-        "Reference documentation": "http://www.projectatomic.io/blog/2016/01/how-to-run-a-more-secure-non-root-user-container/"
+        "Reference documentation": "http://www.projectatomic.io/blog/2016/01/how-to-run-a-more-secure-non-root-user-container/",
+        "Summary": None
     }
     return json_out
+
 
 json_out = template_json_data()
 
@@ -105,20 +107,29 @@ try:
 
     if out is not None:
         json_out["Scan Results"]["Container capabilities"] = out
+
+        if out == "":
+            json_out["Summary"] = "No additional capabilities found."
+        else:
+            json_out["Summary"] = \
+                "Container image has few additional capabilities."
     else:
         json_out["Scan Results"]["Container capabilities"] = \
-            "This container image doesn't require any special capabilities"
+            "This container image doesn't have any special capabilities"
+        json_out["Summary"] = "No additional capabilities found."
 
     json_out["Successful"] = "true"
 
 except RunLabelException as e:
     json_out["Scan Results"]["Container capabilities"] = e.message
     json_out["Successful"] = "false"
+    json_out["Summary"] = "Dockerfile for the image doesn't have RUN label"
 except Exception as e:
     logger.log(
         level=logging.ERROR,
         msg="Scanner failed: {}".format(e)
     )
+    json_out["Summary"] = "Scanner failed"
 finally:
     json_out["Finished Time"] = \
         datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')

--- a/atomic_scanners/container-capabilities-scanner/scanner.py
+++ b/atomic_scanners/container-capabilities-scanner/scanner.py
@@ -53,7 +53,7 @@ def check_image_for_run_label(image):
     run_label = run_object.get_label("RUN")
 
     if run_label == "":
-        raise RunLabelException("Dockerfile for the image doesn't have RUN label")
+        raise RunLabelException("Dockerfile for the image doesn't have RUN label.")
     return run_label
 
 
@@ -123,13 +123,13 @@ try:
 except RunLabelException as e:
     json_out["Scan Results"]["Container capabilities"] = e.message
     json_out["Successful"] = "false"
-    json_out["Summary"] = "Dockerfile for the image doesn't have RUN label"
+    json_out["Summary"] = "Dockerfile for the image doesn't have RUN label."
 except Exception as e:
     logger.log(
         level=logging.ERROR,
         msg="Scanner failed: {}".format(e)
     )
-    json_out["Summary"] = "Scanner failed"
+    json_out["Summary"] = "Scanner failed."
 finally:
     json_out["Finished Time"] = \
         datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')

--- a/atomic_scanners/misc-package-updates/scanner.py
+++ b/atomic_scanners/misc-package-updates/scanner.py
@@ -193,8 +193,8 @@ try:
         json_out["Finished Time"] = \
             datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
         json_out["Successful"] = "true"
-        json_out["Summary"] = "Possible updates for packages installed via "
-        "{}. ".format(cli_arg)
+        json_out["Summary"] = "Possible updates for packages installed via " \
+            "{}. ".format(cli_arg)
 
     # remove the container
     client.remove_container(container=container.get("Id"), force=True)

--- a/atomic_scanners/misc-package-updates/scanner.py
+++ b/atomic_scanners/misc-package-updates/scanner.py
@@ -138,7 +138,7 @@ def template_json_data(scan_type):
         "CVE Feed Last Updated": "NA",
         "Scanner": "Misc Package Updates",
         "Scan Results": {"{} package updates".format(cli_arg): []},
-        "Summary": None
+        "Summary": ""
     }
     return json_out
 

--- a/atomic_scanners/misc-package-updates/scanner.py
+++ b/atomic_scanners/misc-package-updates/scanner.py
@@ -137,9 +137,11 @@ def template_json_data(scan_type):
         "UUID": UUID,
         "CVE Feed Last Updated": "NA",
         "Scanner": "Misc Package Updates",
-        "Scan Results": {"{} package updates".format(cli_arg): []}
+        "Scan Results": {"{} package updates".format(cli_arg): []},
+        "Summary": None
     }
     return json_out
+
 
 json_out = template_json_data(cli_arg)
 
@@ -183,12 +185,16 @@ try:
         json_out["Scan Results"] = \
             "Could not find {} executable in the image".format(cli_arg)
         json_out["Successful"] = "false"
+        json_out["Summary"] = "No updates for packages installed via {}. ".\
+            format(cli_arg)
     else:
         json_out["Scan Results"]["{} package updates".format(cli_arg)] = \
             format_response(cli_arg, response)
         json_out["Finished Time"] = \
             datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
         json_out["Successful"] = "true"
+        json_out["Summary"] = "Possible updates for packages installed via "
+        "{}. ".format(cli_arg)
 
     # remove the container
     client.remove_container(container=container.get("Id"), force=True)

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -39,7 +39,8 @@ def template_json_data(scan_type, uuid, scanner):
         "UUID": uuid[1:],
         "CVE Feed Last Updated": "NA",
         "Scanner": scanner,
-        "Scan Results": {}
+        "Scan Results": {},
+        "Summary": None
     }
     return json_out
 
@@ -90,8 +91,10 @@ class ScanImageRootfs(object):
         resp, err = process.communicate()
 
         if resp != "":
+            self.json_out["Summary"] = "RPM updates available for the image."
             resp = self.parse_yum_check_update(resp)
         else:
+            self.json_out["Summary"] = "No RPM updates pending for the image."
             resp = []
 
         self.json_out['Scan Results']['Package Updates'] = resp

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -40,7 +40,7 @@ def template_json_data(scan_type, uuid, scanner):
         "CVE Feed Last Updated": "NA",
         "Scanner": scanner,
         "Scan Results": {},
-        "Summary": None
+        "Summary": ""
     }
     return json_out
 

--- a/atomic_scanners/scanner-rpm-verify/rpm_verify.py
+++ b/atomic_scanners/scanner-rpm-verify/rpm_verify.py
@@ -76,7 +76,8 @@ class RPMVerify(object):
             "UUID": uuid,
             "CVE Feed Last Updated": "NA",
             "Scanner": scanner,
-            "Scan Results": {}
+            "Scan Results": {},
+            "Summary": None
         }
         return json_out
 
@@ -196,6 +197,11 @@ class RPMVerify(object):
         # print error
         if not result:
             result = ["No issues. Libraries and Binaries are intact."]
+            self.json_out["Summary"] = "Libraries and binaries in the image"\
+                " are intact."
+        else:
+            self.json_out["Summary"] = "RPM verify scanner reported issues "\
+                "with some libraries/binaries."
         return {"rpmVa_issues": result}
 
     def export_results(self, data):

--- a/atomic_scanners/scanner-rpm-verify/rpm_verify.py
+++ b/atomic_scanners/scanner-rpm-verify/rpm_verify.py
@@ -77,7 +77,7 @@ class RPMVerify(object):
             "CVE Feed Last Updated": "NA",
             "Scanner": scanner,
             "Scan Results": {},
-            "Summary": None
+            "Summary": ""
         }
         return json_out
 

--- a/container_pipeline/scanners/pipeline.py
+++ b/container_pipeline/scanners/pipeline.py
@@ -198,7 +198,7 @@ class PipelineScanner(object):
         data["scanner_name"] = self.scanner_name
         if json_data["Scan Results"]["Package Updates"]:
             data["logs"] = json_data
-            data["msg"] = "Container image requires update."
+            data["msg"] = "RPM updates available for the image."
         else:
             data["logs"] = {}
             data["msg"] = "No updates required."


### PR DESCRIPTION
This PR will make sure that the scanners generate summary about the check and add it to the output. It's not modifying the workers. So, the resulting mail will still not contain any summary. That will be handled in the next PR.

We separated these tasks because in CI, atomic scanner images are pulled from r.c.o and not built during the check. So, if a scanner worker is accessing key `Summary`, it's likely going to fail because the output generated by scanner (based on r.c.o images) won't have the key-value pair.