### PR TITLE
Define branch of container-index to look for projects

### DIFF
--- a/ci/lib.py
+++ b/ci/lib.py
@@ -167,6 +167,7 @@ log_level=DEBUG
 openshift_server_ip={openshift_host}
 deployment=ci
 cccp_index_repo=https://github.com/rtnpro/container-index.git
+cccp_index_repo_branch=ci
 db_backup_host_path=/srv/pipeline-logs/db/cccp/
 
 [jenkins_master:vars]

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -166,7 +166,7 @@ production=False
 log_level=DEBUG
 openshift_server_ip={openshift_host}
 deployment=ci
-cccp_index_repo=https://github.com/navidshaikh/cccp-index.git
+cccp_index_repo=https://github.com/centos/container-index.git
 cccp_index_repo_branch=ci
 db_backup_host_path=/srv/pipeline-logs/db/cccp/
 

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -166,7 +166,7 @@ production=False
 log_level=DEBUG
 openshift_server_ip={openshift_host}
 deployment=ci
-cccp_index_repo=https://github.com/rtnpro/container-index.git
+cccp_index_repo=https://github.com/navidshaikh/cccp-index.git
 cccp_index_repo_branch=ci
 db_backup_host_path=/srv/pipeline-logs/db/cccp/
 

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -28,6 +28,8 @@ rsync_ssh_opts=""
 
 # update index repo URL per requirement
 cccp_index_repo=https://github.com/centos/container-index.git
+# branch of cccp_index_repo to poll for container projects, update as required
+cccp_index_repo_branch=master
 
 ## dev environment options, update following to true to configure NFS
 setup_nfs=False

--- a/provisions/roles/jenkins/master/templates/index.yml.j2
+++ b/provisions/roles/jenkins/master/templates/index.yml.j2
@@ -7,7 +7,7 @@
         - git:
             url: "{{ cccp_index_repo }}"
             branches:
-                - "origin/master"
+                - "origin/{{ cccp_index_repo_branch }}"
             skip-tag: True
     triggers:
         - pollscm: "H/10 * * * *"
@@ -30,6 +30,8 @@
     scm:
         - git:
             url: "{{ cccp_index_repo }}"
+            branches:
+                - "origin/{{ cccp_index_repo_branch }}"
             skip-tag: True
     triggers:
         - timed: "59 23 * * 6"


### PR DESCRIPTION
Allow specifying branch of container index in inventory file. With this user can specify the branch of container-index to look for projects to be built.