### PR TITLE
Updating index validation to check prebuild script.

### DIFF
--- a/testindex/constants.py
+++ b/testindex/constants.py
@@ -1,0 +1,2 @@
+PREBUILD_SCRIPT = "prebuild-script"
+PREBUILD_CONTEXT = "prebuild-context"

--- a/testindex/validators.py
+++ b/testindex/validators.py
@@ -122,6 +122,7 @@ class IndexFormatValidator(IndexValidator):
                     id_list.append(entry["id"])
 
             # Check for pre-build script
+            # TODO: This should be updated soon to fail if prebuild-script is not in entry and warn if it is None
             if "prebuild-script" not in entry or ("prebuild-script" in entry and entry["prebuild-script"] is None):
                 self._summary_collector.add_warning("No pre-build script specified.")
 
@@ -320,11 +321,12 @@ class IndexProjectsValidator(IndexValidator):
 
             # * Check for pre-build script
             # TODO : Make a better implementation of pre-build script checking
+            # TODO : Ideally, if prebuild is not in entry, it wont reach here and this should happen if it is not None
             prebuild_exists = False
             if "prebuild-script" in entry:
                 prebuild_exists = True
                 prebuild_script = entry.get("prebuild-script")
-                if prebuild_script and not path.exists(git_path + "/" + str(prebuild_script)):
+                if prebuild_script and not path.exists(path.join(git_path, str(prebuild_script))):
                     self._mark_entry_invalid(entry)
                     self._summary_collector.add_error("Invalid pre-build script path specified")
 

--- a/testindex/validators.py
+++ b/testindex/validators.py
@@ -121,6 +121,10 @@ class IndexFormatValidator(IndexValidator):
                 else:
                     id_list.append(entry["id"])
 
+            # Check for pre-build script
+            if "prebuild-script" not in entry or ("prebuild-script" in entry and entry["prebuild-script"] is None):
+                self._summary_collector.add_warning("No pre-build script specified.")
+
             # Checking app-id field
             if "app-id" not in entry or ("app-id" in entry and entry["app-id"] is None):
                 self._mark_entry_invalid(entry)
@@ -314,8 +318,18 @@ class IndexProjectsValidator(IndexValidator):
 
             container_names[container_name].append(entry["id"])
 
+            # * Check for pre-build script
+            # TODO : Make a better implementation of pre-build script checking
+            prebuild_exists = False
+            if "prebuild-script" in entry:
+                prebuild_exists = True
+                prebuild_script = entry.get("prebuild-script")
+                if prebuild_script and not path.exists(git_path + "/" + str(prebuild_script)):
+                    self._mark_entry_invalid(entry)
+                    self._summary_collector.add_error("Invalid pre-build script path specified")
+
             # * Check for existence of target-file
-            if not path.exists(git_path + "/" + entry["target-file"]):
+            if not prebuild_exists and not path.exists(git_path + "/" + entry["target-file"]):
                 self._mark_entry_invalid(entry)
                 self._summary_collector.add_error("The specified target-file does not exist at the git-path")
 

--- a/testindex/validators.py
+++ b/testindex/validators.py
@@ -1,3 +1,4 @@
+import constants
 from os import path, getcwd, chdir, system
 
 from yaml import load
@@ -121,13 +122,13 @@ class IndexFormatValidator(IndexValidator):
                 else:
                     id_list.append(entry["id"])
 
-            # Check for pre-build script and pre-build path
-            if "prebuild-script" in entry and entry["prebuild-script"] is not None:
-                prebuild_path = entry.get("prebuild-path")
+            # Check for pre-build script and pre-build context
+            if constants.PREBUILD_SCRIPT in entry and entry[constants.PREBUILD_SCRIPT] is not None:
+                prebuild_path = entry.get(constants.PREBUILD_CONTEXT)
                 if not prebuild_path:
                     self._mark_entry_invalid(entry)
                     self._summary_collector.add_error("If pre-build script is specified,"
-                                                      " then prebuild-path should also "
+                                                      " then prebuild-context should also "
                                                       "be specified")
 
             # Checking app-id field
@@ -327,12 +328,12 @@ class IndexProjectsValidator(IndexValidator):
             # TODO : Make a better implementation of pre-build script checking
             # TODO : Ideally, if prebuild is not in entry, it wont reach here and this should happen if it is not None
             prebuild_exists = False
-            if "prebuild-script" in entry and "prebuild-path" in entry:
+            if constants.PREBUILD_SCRIPT in entry and constants.PREBUILD_CONTEXT in entry:
                 prebuild_exists = True
-                prebuild_script = entry.get("prebuild-script")
-                prebuild_path = entry.get("prebuild-path")
+                prebuild_script = entry.get(constants.PREBUILD_SCRIPT)
+                prebuild_context = entry.get(constants.PREBUILD_CONTEXT)
                 if (prebuild_script and not path.exists(path.join(git_path, prebuild_script))
-                    and prebuild_path and not path.exists(path.join(git_path, prebuild_path))):
+                    and prebuild_context and not path.exists(path.join(git_path, prebuild_context))):
                     self._mark_entry_invalid(entry)
                     self._summary_collector.add_error("Invalid pre-build script or path specified")
 


### PR DESCRIPTION
This also removes the check for target file, if
a prebuild script is specified as in case of
prebuild, the target file is unlikely to already
exist, and will instead be generated as artifact
during prebuild.