### PR TITLE
Changed the jenkins job builder to be called from ci.co jenkins

### DIFF
--- a/ci/job.yml
+++ b/ci/job.yml
@@ -246,3 +246,6 @@
             curl https://raw.githubusercontent.com/CentOS/container-pipeline-service/master/pre_build/cccp_index_pre_build_check.py > cccp_index_pre_build_check.py
             curl https://raw.githubusercontent.com/CentOS/container-pipeline-service/master/pre_build/pre-build-job.yml > pre-build-job.yml
             python cccp_index_pre_build_check.py index.d
+            while read config_file; do
+              jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini update $config_file
+            done <job_template_list.txt

--- a/pre_build/pre-build-job.yml
+++ b/pre_build/pre-build-job.yml
@@ -10,6 +10,7 @@
             prebuild_render: "git@github.com:bamachrn/cccp-pre-build-code.git"
             prebuild_branch: {{ appid }}-{{ jobid }}-{{ desired_tag }}
             prebuild_script: {{ prebuild_script }}
+            prebuild_context: {{ prebuild_context }}
 
 - job-template:
     name: centos-container-pipeline-service-pre-build-{{ appid }}-{{ jobid }}-{{ desired_tag }}
@@ -58,7 +59,7 @@
             $ssh_cmd "ssh-keyscan -t rsa,dsa github.com 2>/dev/null >.ssh/known_hosts"
             rsync -e "ssh $sshopts" -Ha .ssh/git_push_priv_key $CICO_hostname:.ssh/id_rsa
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            $ssh_cmd -t "cd payload && sh {prebuild_script}"
+            $ssh_cmd -t "cd payload/{prebuild_context} && sh {prebuild_script}"
             rtn_code=$?
 
             if [ $rtn_code -eq 0 ]; then


### PR DESCRIPTION
* jenkins job builder is not able to read the job ini while being called from the subprocess.
* same is working properly when being called from jenkins workspace
* this PR writes all the job config file names to a file and then render them from that file