### PR TITLE
Fixes syntax for ensuring data dir exists ansible task

### DIFF
--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Ensure cccp data dir exists
-  file: path= "{{ db_backup_host_path }}" state=directory
+  file:
+    path: '{{ db_backup_host_path }}'
+    state: directory
   sudo: yes
   tags: db
   when: not test


### PR DESCRIPTION
Earlier it was inline parameters for ensuring data dir exists, fixing the syntax to have multi-line parameters. 