### PR TITLE
Uses local dir as data dir for postgresql container

### DIFF
--- a/ci/lib.py
+++ b/ci/lib.py
@@ -232,7 +232,6 @@ scanner_worker
 {scanner_host}
 
 [all:vars]
-db_host= {jenkins_master_host}
 public_registry= {jenkins_slave_host}
 intranet_registry = {jenkins_slave_host}:5000
 copy_ssl_certs=True
@@ -249,7 +248,10 @@ openshift_server_ip={openshift_host}
 deployment=ci
 cccp_index_repo=https://github.com/centos/container-index.git
 cccp_index_repo_branch=ci
+
+db_host= {jenkins_master_host}
 db_backup_host_path=/srv/db/cccp/
+postgresql_uid=26
 
 [jenkins_master:vars]
 jenkins_private_key_file = jenkins.key

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -17,7 +17,7 @@ openshift
 scanner_worker
 
 [sentry]
-jenkins_master
+jenkins-master
 
 [all:vars]
 # update as needed
@@ -50,7 +50,7 @@ allowed_hosts = "['127.0.0.1']"
 # postgresql database related configurations
 # ==========================================
 # needed variables for deployments
-db_host=jenkins_master
+db_host=jenkins-master
 # default:/srv/db/cccp/, update as required
 db_backup_host_path=/srv/db/cccp
 # the postgresql image we are using have uid:26, update as required

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -45,14 +45,16 @@ deployment=production
 # Set log level
 log_level = DEBUG
 
-# postgresql database related configurations
-
-# Needed variable for deployments, default:/srv/pipeline-logs/db/cccp/, update as required
-db_backup_host_path=/srv/pipeline-logs/db/cccp/
-
-db_host=jenkins_master
-
 allowed_hosts = "['127.0.0.1']"
+
+# postgresql database related configurations
+# ==========================================
+# needed variables for deployments
+db_host=jenkins_master
+# default:/srv/db/cccp/, update as required
+db_backup_host_path=/srv/db/cccp
+# the postgresql image we are using have uid:26, update as required
+postgresql_uid=26
 
 [jenkins_master:vars]
 # update as needed

--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -7,11 +7,16 @@
   tags: db
   when: not test
 
-- name: Set selinux context for datadir for mounting in containers
-  sefcontext:
-      target: '{{ db_backup_host_path }}'
-      setype: svirt_sandbox_file_t
-      state: present
+- name: Set ACL for data dir on host
+  acl:
+    path: '{{ db_backup_host_path }}'
+    default: yes
+    entity: '{{ postgresql_uid }}'
+    etype: user
+    follow: no
+    permissions: wx
+    recursive: yes
+    state: present
   sudo: yes
   tags: db
 
@@ -35,7 +40,7 @@
       name: postgres
       image: registry.centos.org/sclo/postgresql-95-centos7
       volumes:
-          - "{{ db_backup_host_path }}:/var/lib/pgsql/data"
+          - "{{ db_backup_host_path }}:/var/lib/pgsql/data:Z"
       ports:
           - "{{ db_host }}:{{ db_port }}:5432"
       env:

--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -5,7 +5,6 @@
     state: directory
   sudo: yes
   tags: db
-  when: not test
 
 - name: Set ACL for data dir on host
   acl:
@@ -51,23 +50,6 @@
       restart_policy: on-failure
   sudo: yes
   tags: db
-  when: not test
-
-- name: Run postgres container in CI environment
-  docker_container:
-    name: postgres
-    image: registry.centos.org/sclo/postgresql-95-centos7
-    ports:
-      - "{{ db_host }}:{{ db_port }}:5432"
-    env:
-      POSTGRESQL_USER: '{{ db_user }}'
-      POSTGRESQL_PASSWORD: '{{ db_pass }}'
-      POSTGRESQL_DATABASE: '{{ db_name }}'
-    state: started
-    restart_policy: on-failure
-  sudo: yes
-  tags: db
-  when: test
 
 - name: Wait for 20 seconds for the db to come up
   pause:


### PR DESCRIPTION
Use local directory as data dir with postgresql container and set right ACL for same.

This change-set also parameterize the uid for postgresql container. Default is `26` as mentioned in postgresql [Dockerfile](https://github.com/sclorg/postgresql-container/blob/master/9.5/Dockerfile#L68). 

The uid can be overridden while creating container, and thus one can change the value of same in inventory file.

Also updates the default path given in inventory file to `/srv/db/cccp/` since, earlier path default path was mistakenly given in logs NFS path.