### PR TITLE
Export deploy logs in a file, cat only if deploy fails

### DIFF
--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -100,6 +100,7 @@ if __name__ == '__main__':
     try:
         # get nodes from CICO infra
         nodes = get_nodes(count=5)
+        _print(str(nodes))
     except Exception as e:
         _print('Build failed while receiving nodes from CICO: %s' % e)
         _if_debug()
@@ -114,7 +115,7 @@ if __name__ == '__main__':
     except Exception as e:
         _print('Build failed in either deployment or running builds: %s' % e)
         # first cat the deployment logs, nodes[4] = controller node
-        _print(run_cmd('cat %s' % DEPLOY_LOGS_PATH, host=nodes[4]))
+        _print(run_cmd('cat %s' % DEPLOY_LOGS_PATH, host=nodes[-1]))
         # then cat the cccp.log, nodes[1] = jenkins slave
         _print(run_cmd('cat /srv/pipeline-logs/cccp.log', host=nodes[1]))
         _if_debug()

--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -12,7 +12,8 @@ import json
 import os
 import sys
 
-from ci.lib import _print, setup, test, teardown, run_cmd
+from ci.lib import _print, setup, test, teardown, run_cmd, DEPLOY_LOGS_PATH
+
 
 DEBUG = os.environ.get('ghprbCommentBody', None) == '#dotests-debug'
 ver = "7"
@@ -112,9 +113,10 @@ if __name__ == '__main__':
         })
     except Exception as e:
         _print('Build failed in either deployment or running builds: %s' % e)
-        # TODO: cat deployment logs
-        _print(run_cmd('cat /srv/pipeline-logs/cccp.log',
-                       host=nodes[1]))
+        # first cat the deployment logs, nodes[4] = controller node
+        _print(run_cmd('cat %s' % DEPLOY_LOGS_PATH, host=nodes[4]))
+        # then cat the cccp.log, nodes[1] = jenkins slave
+        _print(run_cmd('cat /srv/pipeline-logs/cccp.log', host=nodes[1]))
         _if_debug()
         sys.exit(1)
 

--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
     except Exception as e:
         _print('Build failed in either deployment or running builds: %s' % e)
         # first cat the deployment logs, nodes[4] = controller node
-        _print(run_cmd('cat %s' % DEPLOY_LOGS_PATH, host=nodes[-1]))
+        _print(run_cmd('cat %s' % DEPLOY_LOGS_PATH, host=nodes[4]))
         # then cat the cccp.log, nodes[1] = jenkins slave
         _print(run_cmd('cat /srv/pipeline-logs/cccp.log', host=nodes[1]))
         _if_debug()

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -355,7 +355,7 @@ def setup(nodes, options):
     jenkins_slave_host = nodes[1]
     openshift_host = nodes[2]
     scanner_host = nodes[3]
-    controller = nodes.pop()
+    controller = nodes[4]
 
     # generate deployment nodes and hostnames text
     nodes_env = (
@@ -415,7 +415,8 @@ def setup(nodes, options):
     # configure SELinux Permissive mode for openshift host
     run_cmd('setenforce 0', host=openshift_host)
 
-    setup_ssh_access(controller, nodes + [controller])
+    # setup controller to rest nodes ssh access
+    setup_ssh_access(controller, nodes[:-1])
     setup_controller(controller)
     sync_controller(controller)
 

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -9,6 +9,8 @@ PROJECT_DIR = os.path.abspath(
                  '..')
 )
 
+DEPLOY_LOGS_PATH = "/tmp/deploy.logs"
+
 
 def _print(msg):
     """
@@ -180,10 +182,10 @@ class ProvisionHandler(object):
             "cd {workdir} && "
             "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i {inventory} "
             "-u {user} -s {private_key_args} {extra_args} "
-            "provisions/main.yml"
+            "provisions/main.yml >> {deploy_logs_path}"
         ).format(workdir=workdir, inventory=inventory, user=user,
                  private_key_args=private_key_args,
-                 extra_args=extra_args)
+                 extra_args=extra_args, deploy_logs_path=DEPLOY_LOGS_PATH)
         _print('Provisioning command: %s' % cmd)
 
         # run the command

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -399,7 +399,7 @@ def setup(nodes, options):
     }
 
     # prints hosts details on CI console
-    _print(hosts_data)
+    _print("=" * 30 + "Hosts data" + "=" * 30 + "\n%s" % hosts_data)
 
     # generate the needed inventory file for provisioning
     generate_ansible_inventory(jenkins_master_host,

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -9,7 +9,7 @@ PROJECT_DIR = os.path.abspath(
                  '..')
 )
 
-DEPLOY_LOGS_PATH = "/tmp/deploy.logs"
+DEPLOY_LOGS_PATH = "/root/deploy.logs"
 
 
 def _print(msg):
@@ -182,7 +182,7 @@ class ProvisionHandler(object):
             "cd {workdir} && "
             "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i {inventory} "
             "-u {user} -s {private_key_args} {extra_args} "
-            "provisions/main.yml >> {deploy_logs_path}"
+            "provisions/main.yml > {deploy_logs_path}"
         ).format(workdir=workdir, inventory=inventory, user=user,
                  private_key_args=private_key_args,
                  extra_args=extra_args, deploy_logs_path=DEPLOY_LOGS_PATH)


### PR DESCRIPTION
To have better CI console logs, only needed information is exported.