### PR TITLE
Separates ansible-deployment and running test builds in CI

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -1,0 +1,12 @@
+import os
+
+PROJECT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__),
+                 '..')
+)
+
+DEPLOY_LOGS_PATH = "/root/deploy.logs"
+JENKINS_HOSTNAME = "localhost"
+JENKINS_HTTP_PORT = 8080
+JENKINS_JAR_LOCATION = "/opt/jenkins-cli.jar"
+CI_TEST_JOB_NAME = "bamachrn-python"

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -6,16 +6,12 @@ import sys
 
 from time import sleep
 
-
-PROJECT_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__),
-                 '..')
-)
-
-DEPLOY_LOGS_PATH = "/root/deploy.logs"
-JENKINS_HOSTNAME = "localhost"
-JENKINS_HTTP_PORT = 8080
-JENKINS_JAR_LOCATION = "/opt/jenkins-cli.jar"
+from constants import PROJECT_DIR,\
+                      DEPLOY_LOGS_PATH,\
+                      JENKINS_HOSTNAME,\
+                      JENKINS_HTTP_PORT,\
+                      JENKINS_JAR_LOCATION,\
+                      CI_TEST_JOB_NAME
 
 
 def _print(msg):
@@ -453,10 +449,10 @@ def run_cccp_index_job(jenkins_master):
     # build command for running cccp-index job
     cmd = ("java -jar {jar_location} -s http://{jenkins_hostname}:{http_port} "
            "build cccp-index -f -v").format(
-            jar_location=JENKINS_JAR_LOCATION,
-            jenkins_hostname=JENKINS_HOSTNAME,
-            http_port=JENKINS_HTTP_PORT
-            )
+        jar_location=JENKINS_JAR_LOCATION,
+        jenkins_hostname=JENKINS_HOSTNAME,
+        http_port=JENKINS_HTTP_PORT
+    )
     # run the command store the results to check further
     out = run_cmd(cmd, host=jenkins_master)
 
@@ -465,14 +461,13 @@ def run_cccp_index_job(jenkins_master):
         raise Exception("Failed running cccp-index job. Exiting!")
 
     # check if test job is created
-    CI_TEST_JOB_NAME = "bamachrn-python"
-
     cmd = ("java -jar {jar_location} -s http://{jenkins_hostname}:{http_port} "
            "list-jobs").format(
-            jar_location=JENKINS_JAR_LOCATION,
-            jenkins_hostname=JENKINS_HOSTNAME,
-            http_port=JENKINS_HTTP_PORT
-            )
+        jar_location=JENKINS_JAR_LOCATION,
+        jenkins_hostname=JENKINS_HOSTNAME,
+        http_port=JENKINS_HTTP_PORT
+    )
+    # retry 50 times with 10 seconds interval
     for i in range(50):
         jenkins_jobs = run_cmd(cmd, host=jenkins_master)
         if CI_TEST_JOB_NAME not in jenkins_jobs:
@@ -489,10 +484,10 @@ def run_cccp_index_job(jenkins_master):
     # now finally disable the jenkins jobs, since we need one time run only
     cmd = ("java -jar {jar_location} -s http://{jenkins_hostname}:{http_port} "
            " disable-job").format(
-           jar_location=JENKINS_JAR_LOCATION,
-           jenkins_hostname=JENKINS_HOSTNAME,
-           http_port=JENKINS_HTTP_PORT
-           )
+        jar_location=JENKINS_JAR_LOCATION,
+        jenkins_hostname=JENKINS_HOSTNAME,
+        http_port=JENKINS_HTTP_PORT
+    )
     # disable the jobs one by one
     for job in jenkins_jobs:
         # append the job name at the end of command and execute

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -433,7 +433,7 @@ def setup(nodes, options):
 def run_cccp_index_job(jenkins_master):
     """Run cccp-index job configured in Jenkins
 
-    Running this job on jenkins populates projects in jenkins.
+    Running this job on jenkins master populates projects in jenkins.
     The populated projects job details are listed in cccp-index
     pointed by service.
     This function uses java commands and jenkins master end point

--- a/provisions/roles/ci/tasks/ci.yml
+++ b/provisions/roles/ci/tasks/ci.yml
@@ -2,27 +2,3 @@
 - name: Enable cccp-index job
   shell: java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} enable-job cccp-index
   when: test
-
-- name: Run cccp-index job
-  shell: java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} build cccp-index -f -v
-  when: test
-  register: result
-
-- name: cccp-index job build output
-  debug: msg="{{ result['stdout'] }}"
-  failed_when: "'Finished: ERROR' in result['stdout']"
-  when: test
-
-- name: Wait for test job to create
-  shell:  java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} list-jobs
-  register: result
-  until: result.stdout.find("bamachrn-python") != -1
-  retries: 50
-  delay: 10
-  when: test
-
-- name: Disable jenkins jobs
-  shell: |
-      for job in `java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} list-jobs`; do
-          java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} disable-job $job;
-      done


### PR DESCRIPTION
To ensure we execute different operations separately and have control over what is failing.