### PR TITLE
Set appropriate default value for build context

### DIFF
--- a/jenkinsbuilder/cccp_index_reader.py
+++ b/jenkinsbuilder/cccp_index_reader.py
@@ -110,7 +110,7 @@ def get_projects_from_index(indexdlocation):
 
                         build_context = project.get("build-context")
                         if not build_context:
-                            build_context = "."
+                            build_context = "./"
 
                         desiredtag = str(desiredtag)
 

--- a/provisions/roles/jenkins/slave/templates/template.json.j2
+++ b/provisions/roles/jenkins/slave/templates/template.json.j2
@@ -86,7 +86,8 @@
     },
     {
       "name": "BUILD_CONTEXT",
-      "description": "The build context for the container build"
+      "description": "The build context for the container build",
+      "value": "./"
     }
   ],
   "objects": [


### PR DESCRIPTION
This PR sets a default value for `build_context` and `BUILD_CONTEXT` parameters. Absence of this default value in the OpenShift template caused CI to fail for PR #383 