### PR TITLE
Adds cron job to delete postgres dump older than N days

### DIFF
--- a/provisions/group_vars/all
+++ b/provisions/group_vars/all
@@ -21,6 +21,8 @@ db_host: '0.0.0.0'
 db_port: 5432
 postgresql_image: registry.centos.org/centos/postgresql-95-centos7
 postgresql_uid: 26
+# expire the cccp database pg_dump tar files after given number of days
+expire_tar_after: 4
 
 allowed_hosts: "['127.0.0.1']"
 

--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -99,3 +99,20 @@
   tags:
     - db
     - cron
+
+- name: Copy cron script to delete old pg_dump tar files
+  sudo: yes
+  template: src=cron_delete_pg_dump_tars.sh.j2 dest=/root/cron_delete_pg_dump_tars.sh mode=0755
+  tags:
+    - db
+    - cron
+
+- name: Cron job to delete old pg_dump tar files daily
+  sudo: yes
+  cron:
+      name: "Cron to delete old pg_dump tar files daily"
+      job: "/root/cron_delete_pg_dump_tars.sh"
+      special_time: daily
+  tags:
+    - db
+    - cron

--- a/provisions/roles/db/templates/cron_delete_pg_dump_tars.sh.j2
+++ b/provisions/roles/db/templates/cron_delete_pg_dump_tars.sh.j2
@@ -1,10 +1,10 @@
 #!/bin/bash
 BACKUPDIR="{{ db_backup_nfs_path}}"
-DAYS=3
+DAYS="{{ expire_tar_after }}"
 
 echo "-----------------------------------------------------------------------------------------------"
-echo "`date +'%F %T'` Removing the repetitve postgresql cccp database tar files older than $DAYS days"
-
+echo "`date +'%F %T'` Removing postgresql cccp database tar files older than $DAYS days from $BACKUPDIR"
+# find all files matching *cccp-pgdump.tar pattern older than $DAYS and delete
 find $BACKUPDIR -type f -name "*cccp-pgdump.tar" -atime +$DAYS -delete
 echo "Deleted postgresql cccp database tar dump files older than $DAYS days."
 echo "-----------------------------------------------------------------------------------------------"

--- a/provisions/roles/db/templates/cron_delete_pg_dump_tars.sh.j2
+++ b/provisions/roles/db/templates/cron_delete_pg_dump_tars.sh.j2
@@ -1,0 +1,10 @@
+#!/bin/bash
+BACKUPDIR="{{ db_backup_nfs_path}}"
+DAYS=3
+
+echo "-----------------------------------------------------------------------------------------------"
+echo "`date +'%F %T'` Removing the repetitve postgresql cccp database tar files older than $DAYS days"
+
+find $BACKUPDIR -type f -name "*cccp-pgdump.tar" -atime +$DAYS -delete
+echo "Deleted postgresql cccp database tar dump files older than $DAYS days."
+echo "-----------------------------------------------------------------------------------------------"


### PR DESCRIPTION
This changeset adds a cron job to run daily and delete `N` days old pg_dump tar files from NFS directory.
`N` can be configured from `group_vars/all`, default is `N=4`.