### PR TITLE
[DO NOT MERGE] Containerize the Dockerfile linter worker

### DIFF
--- a/ci/tests/base.py
+++ b/ci/tests/base.py
@@ -98,7 +98,7 @@ class BaseTestCase(unittest.TestCase):
     def cleanup_beanstalkd(self):
         print self.run_cmd('sudo systemctl stop cccp_imagescanner',
                            host=self.hosts['jenkins_master']['host'])
-        print self.run_cmd('sudo systemctl stop cccp-dockerfile-lint-worker',
+        print self.run_cmd('sudo docker stop lint-worker',
                            host=self.hosts['jenkins_slave']['host'])
         print self.run_cmd('sudo systemctl stop cccp-scan-worker',
                            host=self.hosts['scanner']['host'])
@@ -115,7 +115,7 @@ class BaseTestCase(unittest.TestCase):
                            'sudo docker start delivery-worker; '
                            'sudo docker start dispatcher-worker',
                            host=self.hosts['jenkins_slave']['host'])
-        print self.run_cmd('sudo systemctl start cccp-dockerfile-lint-worker',
+        print self.run_cmd('sudo docker start lint-worker',
                            host=self.hosts['jenkins_slave']['host'])
         print self.run_cmd('sudo systemctl start cccp-scan-worker',
                            host=self.hosts['scanner']['host'])

--- a/container_pipeline/workers/linter.py
+++ b/container_pipeline/workers/linter.py
@@ -139,7 +139,7 @@ class DockerfileLintWorker(BaseWorker):
                    "run",
                    "--rm",
                    "--volumes-from={}".format(os.uname()[1]),
-                   "registry.centos.org/pipeline-images/dockerfile-lint")
+                   "registry.centos.org/pipeline-images/dockerfile-lint-2")
 
         try:
             out, err = run_cmd_out_err(command)

--- a/container_pipeline/workers/linter.py
+++ b/container_pipeline/workers/linter.py
@@ -134,11 +134,11 @@ class DockerfileLintWorker(BaseWorker):
         """
         Lint the Dockerfile received
         """
-        command = ("docker",
+        command = ("sudo",
+                   "docker",
                    "run",
                    "--rm",
-                   "-v",
-                   "/tmp/scan:/root/scan:Z",
+                   "--volumes-from=`hostname`"
                    "registry.centos.org/pipeline-images/dockerfile-lint")
 
         try:

--- a/container_pipeline/workers/linter.py
+++ b/container_pipeline/workers/linter.py
@@ -138,7 +138,7 @@ class DockerfileLintWorker(BaseWorker):
                    "docker",
                    "run",
                    "--rm",
-                   "--volumes-from=`hostname`"
+                   "--volumes-from={}".format(os.uname()[1]),
                    "registry.centos.org/pipeline-images/dockerfile-lint")
 
         try:

--- a/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
@@ -10,6 +10,7 @@
     - build-worker
     - test-worker
     - delivery-worker
+    - lint-worker
 
 - name: Remove /opt/cccp-service directory
   sudo: yes

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -83,7 +83,7 @@
 - name: Pull Linter image
   sudo: yes
   docker_image:
-      name: registry.centos.org/pipeline-images/dockerfile-lint
+      name: registry.centos.org/pipeline-images/dockerfile-lint-2
       state: present
       force: yes
   tags:

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -93,6 +93,8 @@
       name: registry.centos.org/pipeline-images/dockerfile-lint-worker
       state: present
       force: yes
+  tags:
+      - application
 
 - name: Start Dockerfile Lint worker container
   docker_container:
@@ -106,3 +108,5 @@
           - /usr/bin/oc:/usr/bin/oc
           - /var/run/docker.sock:/var/run/docker.sock
           - /srv/pipeline-logs/:/srv/pipeline-logs:rw
+  tags:
+      - application

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -88,20 +88,21 @@
   tags:
       - application
 
-- name: Copy Dockerfile linter worker
-  copy:
-      src: ../../scripts/cccp-dockerfile-lint-worker.service
-      dest: /etc/systemd/system/cccp-dockerfile-lint-worker.service
-  tags:
-      - application
+- name: Pull Dockerfile Lint worker image
+  docker_image:
+      name: registry.centos.org/pipeline-images/dockerfile-lint-worker
+      state: present
+      force: yes
 
-- name: Reload Dockerfile linter worker systemd service
-  sudo: yes
-  systemd: name=cccp-dockerfile-lint-worker daemon_reload=yes
-  tags:
-      - application
-
-- name: Enable and start Dockerfile linter worker
-  systemd: name=cccp-dockerfile-lint-worker enabled=yes state=restarted
-  tags:
-      - application
+- name: Start Dockerfile Lint worker container
+  docker_container:
+      image: registry.centos.org/pipeline-images/dockerfile-lint-worker
+      name: lint-worker
+      state: started
+      restart: yes
+      detach: True
+      volumes:
+          - /opt/cccp-service:/opt/cccp-service:rw
+          - /usr/bin/oc:/usr/bin/oc
+          - /var/run/docker.sock:/var/run/docker.sock
+          - /srv/pipeline-logs/:/srv/pipeline-logs:rw

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -81,6 +81,7 @@
       - application
 
 - name: Pull Linter image
+  sudo: yes
   docker_image:
       name: registry.centos.org/pipeline-images/dockerfile-lint
       state: present
@@ -89,6 +90,7 @@
       - application
 
 - name: Pull Dockerfile Lint worker image
+  sudo: yes
   docker_image:
       name: registry.centos.org/pipeline-images/dockerfile-lint-worker
       state: present
@@ -97,6 +99,7 @@
       - application
 
 - name: Start Dockerfile Lint worker container
+  sudo: yes
   docker_container:
       image: registry.centos.org/pipeline-images/dockerfile-lint-worker
       name: lint-worker

--- a/server/Dockerfile.linter
+++ b/server/Dockerfile.linter
@@ -1,0 +1,16 @@
+FROM registry.centos.org/dharmit/base
+
+RUN sudo yum -y update && \
+    sudo yum install -y docker epel-release && \
+    sudo yum install -y python-pip PyYAML && \
+    sudo pip install django==1.11.2 psycopg2==2.7.3 && \
+    sudo yum clean all 
+    sudo mkdir /tmp/scan && \
+    sudo chown -R user:user /tmp/scan
+
+ENV PYTHONPATH /opt/cccp-service
+
+WORKDIR /opt/cccp-service
+VOLUME /tmp/scan
+
+CMD ["python", "container_pipeline/workers/linter.py"]

--- a/server/Dockerfile.linter
+++ b/server/Dockerfile.linter
@@ -4,7 +4,7 @@ RUN sudo yum -y update && \
     sudo yum install -y docker epel-release && \
     sudo yum install -y python-pip PyYAML && \
     sudo pip install django==1.11.2 psycopg2==2.7.3 && \
-    sudo yum clean all 
+    sudo yum clean all && \
     sudo mkdir /tmp/scan && \
     sudo chown -R user:user /tmp/scan
 


### PR DESCRIPTION
This PR containerizes the Dockerfile linter worker and modifies the provisioning to spin up a container for it. This PR is dependent on https://github.com/dharmit/dockerfile_lint/pull/1. We need to merge that PR before this is merged.