### PR TITLE
Uses become-method while provisioning service in CI

### DIFF
--- a/ci/lib.py
+++ b/ci/lib.py
@@ -183,8 +183,9 @@ class ProvisionHandler(object):
         cmd = (
             "cd {workdir} && "
             "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i {inventory} "
-            "-u {user} -s {private_key_args} {extra_args} "
-            "provisions/main.yml > {deploy_logs_path}"
+            "-u {user} {private_key_args} {extra_args} "
+            "provisions/main.yml --become-method=sudo --become "
+            "> {deploy_logs_path}"
         ).format(workdir=workdir, inventory=inventory, user=user,
                  private_key_args=private_key_args,
                  extra_args=extra_args, deploy_logs_path=DEPLOY_LOGS_PATH)
@@ -195,6 +196,7 @@ class ProvisionHandler(object):
 
         self._provisioned = True
         return True, out
+
 
 # alias the run method of class to be used later
 provision = ProvisionHandler().run


### PR DESCRIPTION
  Adds `--become-method=sudo --become` options to ansible provisioning
  command for CI. This will remove the warnings from ansible-playbook
  execution and improved visibility for CI console logs.