### PR TITLE
Fails CI if cico couldn't get nodes from duffy after 3 retries

### DIFF
--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -116,9 +116,13 @@ if __name__ == '__main__':
             else:
                 _print(str(nodes))
                 break
+        if CICO_GET_RETRY_COUNT == 0:
+            _print('Build failed while receiving nodes from CICO:\n%s' % e)
+            # _if_debug is not needed, since we dont have even nodes to debug
+            sys.exit(1)
     except Exception as e:
         _print('Build failed while receiving nodes from CICO:\n%s' % e)
-        _if_debug()
+        # _if_debug is not needed, since we dont have even nodes to debug
         sys.exit(1)
 
     try:


### PR DESCRIPTION
  The logic for 3 retries was in place, however missing the termination
  of flow. This changeset checks for retry count and exits the execution.