### PR TITLE
Removes personnel namespaced repository reference

### DIFF
--- a/provisions/roles/repo_tracking/tasks/main.yml
+++ b/provisions/roles/repo_tracking/tasks/main.yml
@@ -88,13 +88,6 @@
   sudo: yes
   tags: repo_tracking
 
-- name: Get container index
-  git:
-    repo: https://github.com/rtnpro/container-index
-    dest: /opt/container-index
-  sudo: yes
-  tags: repo_tracking
-
 - name: Ensure jenkins user can write to log file
   file: path=/srv/pipeline-logs/cccp.log state=file owner=jenkins
   sudo: yes


### PR DESCRIPTION
  Fixes #437
  There was no references made to cloned repository in code, removing
  the operation altogether.