### PR TITLE
Adds docker system prune in cleanup utility

### DIFF
--- a/provisions/roles/cleanup/scanner/tasks/main.yml
+++ b/provisions/roles/cleanup/scanner/tasks/main.yml
@@ -11,7 +11,12 @@
   sudo: yes
   shell: rm -rf /var/lib/docker/volumes/*
 
-- name: Run docker system prune
+- name: Remove dangling images
   sudo: yes
   ignore_errors: yes
-  shell: docker system prune -f
+  shell: docker rmi -f `docker images -q -f dangling=true`
+
+- name: Remove dangling volumes
+  sudo: yes
+  ignore_errors: yes
+  shell: docker volume rm `docker volume ls -q -f dangling=true`

--- a/provisions/roles/cleanup/scanner/tasks/main.yml
+++ b/provisions/roles/cleanup/scanner/tasks/main.yml
@@ -11,7 +11,7 @@
   sudo: yes
   shell: rm -rf /var/lib/docker/volumes/*
 
-- name: Remove images with no name or tag
+- name: Run docker system prune
   sudo: yes
   ignore_errors: yes
-  shell: docker rmi $(docker images -f "dangling=true" -q)
+  shell: docker system prune -f


### PR DESCRIPTION
  This will remove:
	- all stopped containers
	- all volumes not used by at least one container
	- all networks not used by at least one container
	- all dangling images