### PR TITLE
Passes build_context from job info to openshift for builds

### DIFF
--- a/container_pipeline/workers/linter.py
+++ b/container_pipeline/workers/linter.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 reload(sys)
 sys.setdefaultencoding('utf-8')
 
+
 def create_project(queue, job, logger):
     """
     Creates a new project in OpenShift. This function expects a queue on which
@@ -70,7 +71,8 @@ def create_project(queue, job, logger):
             'TARGET_FILE': job.get("target_file"),
             'NOTIFY_EMAIL': job.get("notify_email"),
             'DESIRED_TAG': job.get("desired_tag"),
-            'TEST_TAG': job.get("test_tag")
+            'TEST_TAG': job.get("test_tag"),
+            'BUILD_CONTEXT': job.get("build_context")
         })
     except OpenshiftError:
         try:


### PR DESCRIPTION
  Fixes #459 
  Although build_context is retrieved from YAML files, the value
  was not given to OpenShift via templates for builds.
  The template was using the default value of `./`, causing the projects
  wanting `../` as build context to fail.