### PR TITLE
Fixes logging the extra field in the logger upon exception

### DIFF
--- a/container_pipeline/workers/scan.py
+++ b/container_pipeline/workers/scan.py
@@ -48,9 +48,9 @@ class ScanWorker(BaseWorker):
         status, scanners_data = scan_runner_obj.scan()
         if not status:
             self.logger.warning(
-                "Failed to run scanners on image under test, moving on!",
-                extra=self.job
-            )
+                "Failed to run scanners on image under test, moving on!")
+            self.logger.warning("Job data %s", str(self.job))
+
             self.set_buildphase_data(
                 build_phase_status='complete',
                 build_phase_end_time=timezone.now()


### PR DESCRIPTION
  We were logging `extra=self.job`, where self.job is a dict.
  This causes the logging module to report error that constructor
  is called with more values than expected since the self.job has
  key value pairs.
  The fix is to log self.job by transforming it into a string.