### PR TITLE
Don't verify TLS certificates for registry.

### DIFF
--- a/provisions/roles/registry/tasks/main.yml
+++ b/provisions/roles/registry/tasks/main.yml
@@ -23,4 +23,4 @@
       restart_policy: always
       pull: yes
       published_ports: "9000:8080"
-      command: "--registry {{ public_registry }}"
+      command: "--insecure --registry {{ public_registry }}"


### PR DESCRIPTION
Sometimes the TLS certs are self-generated when deploying. This ignores
invalid certs.