### PR TITLE
Ignore centos base images from repo tracking

### DIFF
--- a/container_pipeline/management/commands/imagescanner.py
+++ b/container_pipeline/management/commands/imagescanner.py
@@ -80,7 +80,7 @@ def scan_image(image):
 
     # if image in question is a centos base image (centos/centos:*), don't scan
     # it for repo tracking.
-    if image.name.startswith("centos/centos"):
+    if image.name.startswith("centos/centos:"):
         image.scanned = True
         image.last_scanned = timezone.now()
         image.save()

--- a/container_pipeline/management/commands/imagescanner.py
+++ b/container_pipeline/management/commands/imagescanner.py
@@ -77,6 +77,15 @@ def populate_upstreams(container):
 
 def scan_image(image):
     """Scan the given container image"""
+
+    # if image in question is a centos base image (centos/centos:*), don't scan
+    # it for repo tracking.
+    if image.name.startswith("centos/centos"):
+        image.scanned = True
+        image.last_scanned = timezone.now()
+        image.save()
+        return
+
     image.pull()
     populate_packages(image)
     populate_upstreams(image)


### PR DESCRIPTION
This PR is meant to ignore images starting with `centos/centos` from repo tracking (RPM updates).