### PR TITLE
Re-initializes the client queue connection on Attribute error

### DIFF
--- a/container_pipeline/lib/queue.py
+++ b/container_pipeline/lib/queue.py
@@ -38,6 +38,16 @@ def retry(delay=30):
                 except QueueEmptyException as e:
                     # do not log "No job in queue message"
                     time.sleep(30)
+                except AttributeError as ae:
+                    # this is to log issues where methods
+                    # on object self._conn reports attribute error
+                    obj = args[0]
+                    obj.logger.warning(str(ae))
+                    time.sleep(delay)
+                    # the attribute error is not valid for _initialize method
+                    if func != obj._initialize:
+                        # re-initialize the connection
+                        obj._initialize()
         return wrapper
     return _retry
 

--- a/container_pipeline/lib/queue.py
+++ b/container_pipeline/lib/queue.py
@@ -34,10 +34,10 @@ def retry(delay=30):
                 except beanstalkc.DeadlineSoon as e:
                     obj = args[0]
                     obj.logger.debug(e)
-                    time.sleep(30)
+                    time.sleep(delay)
                 except QueueEmptyException as e:
                     # do not log "No job in queue message"
-                    time.sleep(30)
+                    time.sleep(delay)
                 except AttributeError as ae:
                     # this is to log issues where methods
                     # on object self._conn reports attribute error

--- a/container_pipeline/lib/queue.py
+++ b/container_pipeline/lib/queue.py
@@ -33,7 +33,7 @@ def retry(delay=30):
                         obj._initialize()
                 except beanstalkc.DeadlineSoon as e:
                     obj = args[0]
-                    obj.logger.debug(e)
+                    obj.logger.warning(e)
                     time.sleep(delay)
                 except QueueEmptyException as e:
                     # do not log "No job in queue message"


### PR DESCRIPTION
Fixes: #479
To ensure queue handling utilities, which are the single point of blocker can also take care of AttributeErrror exception and tries re-initialization on this exception.

