### PR TITLE
Removes 'not vagrant'

### DIFF
--- a/provisions/roles/jenkins/master/tasks/jobs.yml
+++ b/provisions/roles/jenkins/master/tasks/jobs.yml
@@ -48,7 +48,6 @@
     - ../jenkinsbuilder/project-defaults.yml
     - ../jenkinsbuilder/weekly-scan.py
     - ../container_pipeline/vendors/beanstalkc.py
-  when: not vagrant
   tags:
       - application
 


### PR DESCRIPTION
Vagrant at the moment does not work, regardless, this task is required if Vagrant
is used or not.