### PR TITLE
Force creation of cron.hourly directory

### DIFF
--- a/provisions/roles/jenkins/master/tasks/logrotate.yml
+++ b/provisions/roles/jenkins/master/tasks/logrotate.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable logrotate to run hourly
-  file: src=/etc/cron.daily/logrotate dest=/etc/cron.hourly/logrotate state=link
+  file: src=/etc/cron.daily/logrotate dest=/etc/cron.hourly/logrotate state=link force=yes
   sudo: yes
 
 - name: Enable logrotate for /srv/pipeline-logs/cccp.log


### PR DESCRIPTION
Some CentOS distributions do not have cron installed by default (see
CentOS7 Docker container).

Thus force=yes is required to manually generate / create the folder.