### PR TITLE
Improves deployment of Jenkins via Ansible

### DIFF
--- a/provisions/roles/jenkins/master/tasks/main.yml
+++ b/provisions/roles/jenkins/master/tasks/main.yml
@@ -2,22 +2,39 @@
   tags:
   - jenkins/master
 
+# Stop Jenkins so no files are overriden by a running Jenkins instance
+- name: Stop jenkins before configuration
+  service: name=jenkins state=stopped
+  sudo: yes
+  tags:
+  - jenkins/master
+
 - include: config.yml
   tags:
   - jenkins/master
 
-- name: Restart jenkins
-  service: name=jenkins state=restarted
+# Start Jenkins again
+- name: Start jenkins
+  service: name=jenkins state=started
   sudo: yes
   tags:
   - jenkins/master
 
 - name: Wait for Jenkins to come up
-  shell: curl --head --silent http://localhost:8080/cli/
+  wait_for:
+    host: '{{ansible_default_ipv4.address}}'
+    port: 8080
+    delay: 5
+    timeout: 300
+  tags:
+    - jenkins/master
+
+- name: Wait for Jenkins UI to come up
+  shell: curl --head --silent http://{{ ansible_default_ipv4.address }}:8080/cli/
   register: result
   until: result.stdout.find("200 OK") != -1
   retries: 50
-  delay: 10
+  delay: 5
   tags:
     - jenkins/master
 
@@ -31,11 +48,20 @@
     - jenkins/master
 
 - name: Wait for Jenkins to come up
-  shell: curl --head --silent http://localhost:8080/cli/
+  wait_for:
+    host: '{{ ansible_default_ipv4.address }}'
+    port: 8080
+    delay: 5
+    timeout: 300
+  tags:
+    - jenkins/master
+
+- name: Wait for Jenkins UI to come up
+  shell: curl --head --silent http://{{ ansible_default_ipv4.address }}:8080/cli/
   register: result
   until: result.stdout.find("200 OK") != -1
   retries: 50
-  delay: 10
+  delay: 5
   tags:
     - jenkins/master
 


### PR DESCRIPTION
This PR:

 - Stops the Jenkins master (via systemd) BEFORE configuration takes
 place. There are minor issues where if the configuration is overriden
 while Jenkins is running, configuration settings are potentially
 overridden. After configuration changes are completed, Jenkins is
 started again.
  - Uses ansible's built-in `wait_for` for port 8080 to come up, then
  checks to see if the UI has come up. This reduces the delay duration
  as well as makes it more intuitive (wait for port to come up, then
  curl it)
  - Reduces delays (faster deployment)
  - Makes sure that a shell is created for Jenkins slave user (had
  issues with master+slave communication due to user being directed to
  /run/nologin for some reason)