### PR TITLE
Allow ability to run Docker-in-Docker-in-OpenShift for testing

### DIFF
--- a/provisions/roles/openshift/defaults/main.yml
+++ b/provisions/roles/openshift/defaults/main.yml
@@ -17,7 +17,7 @@ openshift_shared_dirs:
 openshift_volumes:
   - /:/rootfs:ro
   - /var/run:/var/run:rw
-  - /sys:/sys
+  - /sys:/sys:rw
   - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - /var/lib/docker:/var/lib/docker:rw
   - /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave

--- a/provisions/roles/openshift/tasks/config.yml
+++ b/provisions/roles/openshift/tasks/config.yml
@@ -19,6 +19,7 @@
 - name: Set SELinux context for openshift shared dirs
   command: chcon -Rt svirt_sandbox_file_t {{ item }}
   with_items: "{{ openshift_shared_dirs }}"
+  tags: selinux
 
 - name: Pull openshift images
   docker_image:
@@ -31,7 +32,56 @@
       - "{{ origin_image_registry }}/{{ origin_image_name }}-docker-registry"
       - "{{ origin_image_registry }}/{{ origin_image_name }}-pod"
 
-- name: Create OpenShift origin container
+
+# Below is due to THIS issue: https://github.com/kubernetes/kubernetes/issues/43856 which we can't do anything about
+# (running Kubernetes docker-in-docker as well as on a CentOS 7 host causes issues...)
+# First we created the configuration so we can append some values
+- name: Create config OpenShift origin container
+  when: deployment == "docker"
+  docker_container:
+    name: origin-config
+    image: "{{ origin_image_registry }}/{{ origin_image_name }}:{{ origin_image_tag }}"
+    privileged: yes
+    pid_mode: host
+    network_mode: host
+    recreate: yes
+    volumes: "{{ openshift_volumes }}"
+    command: start --master=https://"{{ansible_default_ipv4.address}}":8443 --write-config=/var/lib/origin/openshift.local.config
+
+- name: Quick pause to catch up to configuration being propagated
+  when: deployment == "docker"
+  pause:
+    seconds: 30
+
+# Append to the configuration to disable QOS
+# See: https://github.com/kubernetes/kubernetes/issues/43856
+- name: Append to config disabling QoS for OpenShift Origin
+  when: deployment == "docker"
+  lineinfile: 
+    dest: /var/lib/origin/openshift.local.config/node-{{ ansible_hostname }}/node-config.yaml
+    line: '{{ item }}'
+  with_items:
+    - 'kubeletArguments:'
+    - '  cgroups-per-qos:'
+    - '  - "false"' 
+    - '  enforce-node-allocatable:'
+    - '  - ""'
+
+- name: Create test OpenShift origin container
+  when: deployment == "docker"
+  docker_container:
+    name: origin-test
+    image: "{{ origin_image_registry }}/{{ origin_image_name }}:{{ origin_image_tag }}"
+    privileged: yes
+    pid_mode: host
+    network_mode: host
+    volumes: "{{ openshift_volumes }}"
+    command: start --master=https://"{{ansible_default_ipv4.address}}":8443 --node-config=/var/lib/origin/openshift.local.config/node-{{ ansible_hostname }}/node-config.yaml --master-config=/var/lib/origin/openshift.local.config/master/master-config.yaml
+    restart_policy: always
+    restart_retries: 2
+
+- name: Create production OpenShift origin container
+  when: deployment != "docker"
   docker_container:
     name: origin
     image: "{{ origin_image_registry }}/{{ origin_image_name }}:{{ origin_image_tag }}"


### PR DESCRIPTION
A bit of a complicated PR, but essentially, after much trial-and-error,
this is required in order to get OpenShift running within
Docker-in-Docker within a CentOS7 container.

Essentially, what happens, is that OpenShift tries to start Kubelet but
is unable to due to cgroup access within the CentOS7 Container host.

See issue: https://github.com/kubernetes/kubernetes/issues/43856

In the end, it is instead required to:

 1. Generate the default configuration for the all-in-one OpenShift
 origin container
 2. Edit node-config.yaml to ignore QoS containers
 3. Start the OpenShift origin container.

This will only occur if the `deployment` value is set to `test`

Another note is that `selinux` has been added as a tag to "Set SELinux
context for openshift shared dirs" due to selinux not being deployed /
used on CentOS7 containers. This is added so we can use --skip-tag
"selinux" if we are deciding to deploy to CentOS7 containers.