### PR TITLE
Installs latest docker and docker-py packages on every deployment

### DIFF
--- a/provisions/roles/django/tasks/main.yml
+++ b/provisions/roles/django/tasks/main.yml
@@ -14,14 +14,12 @@
   sudo: yes
   tags: django
 
-- name: Install Docker
-  yum: name=docker state=installed
+- name: Install latest docker and python-docker-py packages
+  yum: name={{ item }} state=latest
   sudo: yes
-  tags: django
-
-- name: Install docker-py
-  yum: name=python-docker-py state=installed
-  sudo: yes
+  with_items:
+      - docker
+      - python-docker-py
   tags: django
 
 - name: Install postgresql-devel

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -27,7 +27,7 @@
       line: "            self.mount_paths[chroot_scan_dir] = chroot_scan_dir"
 
 - name: Install docker
-  yum: name=docker state=present
+  yum: name=docker state=latest
   sudo: yes
   tags: scanner
 


### PR DESCRIPTION
  Fixes #493

  Updated the ansible yum install config of `docker` and `python-docker-py`
  packages to `state=latest`.
  Earlier the config was `state=present`.
  This was causing inconsistent version of docker installed on different
  nodes.