### PR TITLE
Remove postgresql container that's not being used anywhere

### DIFF
--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -37,13 +37,6 @@
   sudo: yes
   systemd: name=docker state=started enabled=yes
 
-- name: Pull CentOS postgres container
-  docker_image:
-      name: registry.centos.org/sclo/postgresql-95-centos7
-      tag: latest
-  sudo: yes
-  tags: db
-
 - name: Run postgres container
   docker_container:
       name: postgres

--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -41,6 +41,7 @@
   docker_image:
       name: '{{ postgresql_image }}'
       tag: latest
+      state: present
       force: yes
   sudo: yes
   tags: db

--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -37,6 +37,14 @@
   sudo: yes
   systemd: name=docker state=started enabled=yes
 
+- name: Pull CentOS postgres container
+  docker_image:
+      name: '{{ postgresql_image }}'
+      tag: latest
+      force: yes
+  sudo: yes
+  tags: db
+
 - name: Run postgres container
   docker_container:
       name: postgres


### PR DESCRIPTION
Stop pulling registry.centos.org/sclo/postgresql-95-centos7 container as it's not being used anywhere in the service.