### PR TITLE
Remove patches to installed atomic libs as latest atomic has it

### DIFF
--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -4,28 +4,6 @@
   sudo: yes
   tags: scanner
 
-# Fix for issue:  https://github.com/projectatomic/atomic/issues/804
-- name: Install python-dateutil
-  yum: name=python-dateutil state=present
-  sudo: yes
-  tags: scanner
-
-# Patch from https://github.com/projectatomic/atomic/commit/a261270e727353899675a3fde8f9108376bb27cf
-- name: Patch atomic scanner to run on non tty input
-  replace: >
-      dest=/usr/lib/python2.7/site-packages/Atomic/scan.py
-      regexp="'-it'"
-      replace="'-t'"
-  sudo: yes
-  tags: scanner
-
-# Patch from https://github.com/projectatomic/atomic/pull/1037
-- name: Patch atomic scan to unmount container image's rootfs
-  lineinfile:
-      dest: /usr/lib/python2.7/site-packages/Atomic/scan.py
-      insertafter: "mcmd = ['mount', '-o', 'ro,bind', _dir, chroot_scan_dir]"
-      line: "            self.mount_paths[chroot_scan_dir] = chroot_scan_dir"
-
 - name: Install docker
   yum: name=docker state=latest
   sudo: yes


### PR DESCRIPTION
  Needed hotfixes earlier when patches to atomic did not land in current release.
  Removed patches for:
  - https://github.com/projectatomic/atomic/issues/804
  - https://github.com/projectatomic/atomic/commit/a261270e727353899675a3fde8f9108376bb27cf
  - https://github.com/projectatomic/atomic/pull/1037

Its fixed now, references: 
 - https://github.com/projectatomic/atomic/issues/804#issuecomment-369843914
 - https://github.com/projectatomic/atomic/blob/master/Atomic/scan.py#L488
 - https://github.com/projectatomic/atomic/blob/master/Atomic/scan.py#L157
