### PR TITLE
Installs jjb via RPM, prevents installing virtualenv, and pip install

### DIFF
--- a/provisions/roles/jenkins/master/tasks/jobs.yml
+++ b/provisions/roles/jenkins/master/tasks/jobs.yml
@@ -4,19 +4,7 @@
   when: enable_epel
 
 - name: Ensure JJB is installed
-  yum: name={{ item }} state=present
-  with_items:
-    - python-setuptools
-    - python-virtualenv
-
-- name: Create virtualenv
-  shell: "virtualenv /opt/cccp-service/venv"
-
-- name: Install jenkins-job-builder in venv
-  shell: "/opt/cccp-service/venv/bin/pip install jenkins-job-builder"
-
-- name: Link jjb binary to /usr/bin
-  file: src="/opt/cccp-service/venv/bin/jenkins-jobs" dest=/usr/bin/jenkins-jobs state=link mode=a+x
+  yum: name=python2-jenkins-job-builder state=latest
 
 - name: Ensure JJB conf dir exists
   file: dest=/etc/jenkins_jobs state=directory


### PR DESCRIPTION
  Earlier, we installed virtualenv, setuptools, pip version of jjb,
  linked binary in /usr/bin to make available `jenkins-jobs` command
  line. The bunch of operations can be clubbed if installed jjb via RPM.
  Saves deployment time, prevent using pip for production use.