### PR TITLE
Enabling automatic gc runs in cron.

### DIFF
--- a/provisions/roles/jenkins/slave/tasks/cleanup_registry.yml
+++ b/provisions/roles/jenkins/slave/tasks/cleanup_registry.yml
@@ -3,5 +3,5 @@
 - name: Copy cron script to clean up mismatched tags from registry
   template: src=cron_delete_index_mismatch.sh.j2 dest=/root/cron_delete_index_mismatch.sh mode=0755
 
-#- name: Add cronjob to clean up mismatched tags from registry
-#  cron: name="To delete mismatched containers from registry" hour="*/24" job=/root/cron_delete_index_mismatch.sh
+- name: Add cronjob to clean up mismatched tags from registry
+  cron: name="To delete mismatched containers from registry" hour="*/6" job=/root/cron_delete_index_mismatch.sh


### PR DESCRIPTION
This enables garbage collector to run regulary through cron and also includes a temporary fix for overflowing catalog size.

Update : Overflowing catalog is taken care of by pagination pr (https://github.com/CentOS/container-pipeline-service/pull/518), so rebased on that and now only enabling gc in cron