### PR TITLE
No need of restart retry when restart is set to always

### DIFF
--- a/provisions/roles/openshift/tasks/config.yml
+++ b/provisions/roles/openshift/tasks/config.yml
@@ -41,7 +41,6 @@
     volumes: "{{ openshift_volumes }}"
     command: start --master=https://"{{ansible_default_ipv4.address}}":8443
     restart_policy: always
-    restart_retries: 2
 
 - name: Wait for Openshift to come up
   pause: seconds={{ openshift_startup_delay }}


### PR DESCRIPTION
When container is set to always restart, docker complains on seeing the restart retries. This PR removes the restart retries to make the container work on restart always mode.