### PR TITLE
Fixed all the registry endpoints to get proper value in GUI

### DIFF
--- a/ci/lib.py
+++ b/ci/lib.py
@@ -273,7 +273,7 @@ scanner_worker
 
 [all:vars]
 db_host= {jenkins_master_host}
-public_registry= {jenkins_slave_host}
+public_registry= {jenkins_slave_host}:5000
 intranet_registry = {jenkins_slave_host}:5000
 copy_ssl_certs=True
 openshift_startup_delay=150

--- a/ci/lib.py
+++ b/ci/lib.py
@@ -273,7 +273,7 @@ scanner_worker
 
 [all:vars]
 db_host= {jenkins_master_host}
-public_registry= {jenkins_slave_host}:5000
+public_registry= {jenkins_slave_host}
 intranet_registry = {jenkins_slave_host}:5000
 copy_ssl_certs=True
 openshift_startup_delay=150

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -29,7 +29,8 @@ logrotate_rotate=5
 # Set log level
 log_level = DEBUG
 # configure registry node
-public_registry=jenkins-slave
+#for prod public_registry=registry.centos.org 
+public_registry=jenkins-slave:5000
 intranet_registry=jenkins-slave:5000
 # configure beanstalkd server node
 beanstalk_server=open-shift

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -30,7 +30,7 @@ logrotate_rotate=5
 log_level = DEBUG
 # configure registry node
 #for prod public_registry=registry.centos.org 
-public_registry=jenkins-slave:5000
+public_registry=jenkins-slave
 intranet_registry=jenkins-slave:5000
 # configure beanstalkd server node
 beanstalk_server=open-shift

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -8,7 +8,7 @@
 - name: Enable Docker registry
   lineinfile:
     dest: /etc/sysconfig/docker
-    line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }}"'
+    line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }} --add-registry {{ intranet_registry }}"'
 
 - name: Reload docker systemd service
   become: true

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -8,7 +8,7 @@
 - name: Enable Docker registry
   lineinfile:
     dest: /etc/sysconfig/docker
-    line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }} --add-registry {{ intranet_registry }}"'
+    line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ intranet_registry }}"'
 
 - name: Reload docker systemd service
   become: true

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -8,7 +8,7 @@
 - name: Enable Docker registry
   lineinfile:
     dest: /etc/sysconfig/docker
-    line: 'ADD_REGISTRY="--add-registry {{ public_registry }}:5000 --add-registry registry.centos.org"'
+    line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }}"'
 
 - name: Reload docker systemd service
   become: true

--- a/provisions/roles/jenkins/slave/templates/template.json.j2
+++ b/provisions/roles/jenkins/slave/templates/template.json.j2
@@ -31,7 +31,7 @@
 	{
       "name": "TARGET_REGISTRY",
       "description": "An URL of a registry where to push the final image",
-      "value": "{{ public_registry }}:5000"
+      "value": "{{ intranet_registry }}"
     },
     {
       "name": "APPID",

--- a/provisions/roles/openshift/defaults/main.yml
+++ b/provisions/roles/openshift/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 origin_image_registry: docker.io
 origin_image_name: openshift/origin
-origin_image_tag: v3.6.0
+origin_image_tag: v3.7.1
 
 origin_dir: /var/lib/origin
 

--- a/provisions/roles/openshift/tasks/config.yml
+++ b/provisions/roles/openshift/tasks/config.yml
@@ -7,7 +7,7 @@
 - name: Enable Docker registry
   lineinfile:
     dest: /etc/sysconfig/docker
-    line: 'ADD_REGISTRY="--add-registry {{ public_registry }}"'
+    line: 'ADD_REGISTRY="--add-registry {{ public_registry }} --add-registry {{ intranet_registry }}"'
 
 - name: Restart Docker
   service: name=docker state=restarted enabled=yes

--- a/provisions/roles/openshift/tasks/config.yml
+++ b/provisions/roles/openshift/tasks/config.yml
@@ -7,7 +7,7 @@
 - name: Enable Docker registry
   lineinfile:
     dest: /etc/sysconfig/docker
-    line: 'ADD_REGISTRY="--add-registry {{ public_registry }} --add-registry registry.centos.org"'
+    line: 'ADD_REGISTRY="--add-registry {{ public_registry }}"'
 
 - name: Restart Docker
   service: name=docker state=restarted enabled=yes

--- a/provisions/roles/repo_tracking/tasks/main.yml
+++ b/provisions/roles/repo_tracking/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Enable Docker Registry
   lineinfile:
       dest: /etc/sysconfig/docker
-      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }}"'
+      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }} --add-registry {{ intranet_registry }}"'
   tags: repo_tracking
 
 - name: Enable access to Docker daemon over TCP in localhost

--- a/provisions/roles/repo_tracking/tasks/main.yml
+++ b/provisions/roles/repo_tracking/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Enable Docker Registry
   lineinfile:
       dest: /etc/sysconfig/docker
-      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }} --add-registry registry.centos.org"'
+      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }}"'
   tags: repo_tracking
 
 - name: Enable access to Docker daemon over TCP in localhost

--- a/provisions/roles/repo_tracking/tasks/main.yml
+++ b/provisions/roles/repo_tracking/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Enable Docker Registry
   lineinfile:
       dest: /etc/sysconfig/docker
-      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }} --add-registry {{ intranet_registry }}"'
+      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ intranet_registry }}"'
   tags: repo_tracking
 
 - name: Enable access to Docker daemon over TCP in localhost

--- a/provisions/roles/repo_tracking/templates/settings.py.j2
+++ b/provisions/roles/repo_tracking/templates/settings.py.j2
@@ -15,6 +15,6 @@ DATABASES = {
         'PORT': '{{ db_port }}'
     }
 }
-REGISTRY_ENDPOINT = ('{{ public_registry }}:5000', '{{ public_registry }}:5000')
+REGISTRY_ENDPOINT = ('{{ intranet_registry }}', '{{ public_registry }}')
 BEANSTALK_SERVER = '{{ beanstalk_server }}'
 ALLOWED_HOSTS = {{ allowed_hosts }}

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Enable Docker Registry
   lineinfile:
       dest: /etc/sysconfig/docker
-      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }}"'
+      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ intranet_registry }}"'
   tags: scanner
 
 - name: Set SELinux to permissive

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Enable Docker Registry
   lineinfile:
       dest: /etc/sysconfig/docker
-      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }} --add-registry registry.centos.org"'
+      line: 'ADD_REGISTRY="--insecure-registry {{ intranet_registry }} --add-registry {{ public_registry }}"'
   tags: scanner
 
 - name: Set SELinux to permissive

--- a/provisions/templates/cron_delete_index_mismatch.sh.j2
+++ b/provisions/templates/cron_delete_index_mismatch.sh.j2
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-/usr/bin/python /opt/cccp-service/container_pipeline/cleanup_registry/__init__.py -cr {{ public_registry }} -p 5000 \
+/usr/bin/python /opt/cccp-service/container_pipeline/cleanup_registry/__init__.py -cr {{ intranet_registry }} -p 5000 \
     -i {{ cccp_index_repo }};

--- a/provisions/templates/settings.py.j2
+++ b/provisions/templates/settings.py.j2
@@ -26,7 +26,7 @@ for value in LOGGING['loggers'].values():
     value['handlers'].append('sentry')
 {% endif %}
 
-REGISTRY_ENDPOINT = ('{{ public_registry }}:5000', '{{ public_registry }}:5000')
+REGISTRY_ENDPOINT = ('{{ intranet_registry }}', '{{ public_registry }}')
 BEANSTALK_SERVER = '{{ beanstalk_server }}'
 
 STATIC_ROOT = "/opt/cccp-service/static"


### PR DESCRIPTION
Fixes: https://github.com/CentOS/container-pipeline-service/issues/508
Fixes: https://github.com/CentOS/container-pipeline-service/issues/574
This takes into consideration that
1. `public registry` is reachable by the internal builds. so in inventory file for deployment **other than** prod, it sholud be  `{jenkins_slave}`. And in prod it should be `registry.cento.org`
1. `intranet registry` is for insecure registry we push to. so in inventory fle has value `{jenkins_slave}:5000`