### PR TITLE
Reports pipeline-scanner errors upon unusual input, prevents scanner from crashing

### DIFF
--- a/atomic_scanners/pipeline-scanner/Dockerfile
+++ b/atomic_scanners/pipeline-scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM registry.centos.org/centos/centos
 
 LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -69,7 +69,16 @@ class ScanImageRootfs(object):
 
     def scan_release(self):
         env_vars_dict = dict()
-        with open(os.path.join(self.in_path, "etc/os-release")) as f:
+        etc_os_release = os.path.join(self.in_path, "etc/os-release")
+
+        if not os.path.isfile(etc_os_release):
+            self.json_out["Scan Results"]["OS Release"] = \
+                "Could not find OS release of image under test " \
+                "as /etc/os-release file does not exist."
+            return
+        # check if at all /etc/os-release exist even before opening it
+
+        with open(etc_os_release) as f:
             env_vars = f.readlines()
 
         for var in env_vars:

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -34,7 +34,7 @@ def template_json_data(scan_type, uuid, scanner):
     current_time = datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
     json_out = {
         "Start Time": current_time,
-        "Successful": "true",
+        "Successful": False,
         "Scan Type": scan_type,
         "UUID": uuid[1:],
         "CVE Feed Last Updated": "NA",
@@ -71,12 +71,12 @@ class ScanImageRootfs(object):
         env_vars_dict = dict()
         etc_os_release = os.path.join(self.in_path, "etc/os-release")
 
+        # check if at all /etc/os-release exist even before opening it
         if not os.path.isfile(etc_os_release):
             self.json_out["Scan Results"]["OS Release"] = \
                 "Could not find OS release of image under test " \
                 "as /etc/os-release file does not exist."
             return
-        # check if at all /etc/os-release exist even before opening it
 
         with open(etc_os_release) as f:
             env_vars = f.readlines()
@@ -101,6 +101,7 @@ class ScanImageRootfs(object):
 
         if resp != "":
             self.json_out["Summary"] = "RPM updates available for the image."
+            self.json_out["Successful"] = True
             resp = self.parse_yum_check_update(resp)
         else:
             if "rpmdb open failed" in err:
@@ -111,6 +112,7 @@ class ScanImageRootfs(object):
             else:
                 self.json_out["Summary"] = \
                     "No RPM updates pending for the image." % str(err)
+                self.json_out["Successful"] = True
             resp = []
 
         self.json_out['Scan Results']['Package Updates'] = resp

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -103,7 +103,12 @@ class ScanImageRootfs(object):
             self.json_out["Summary"] = "RPM updates available for the image."
             resp = self.parse_yum_check_update(resp)
         else:
-            self.json_out["Summary"] = "No RPM updates pending for the image."
+            if "file not found in $PATH" in err:
+                self.json_out["Summary"] = \
+                    "yum binary is not available in image under test."
+            else:
+                self.json_out["Summary"] = \
+                    "No RPM updates pending for the image."
             resp = []
 
         self.json_out['Scan Results']['Package Updates'] = resp

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -103,12 +103,14 @@ class ScanImageRootfs(object):
             self.json_out["Summary"] = "RPM updates available for the image."
             resp = self.parse_yum_check_update(resp)
         else:
-            if "file not found in $PATH" in err:
+            if "rpmdb open failed" in err:
                 self.json_out["Summary"] = \
-                    "yum binary is not available in image under test."
+                    "Failed to open rpmdb in image under test, " \
+                    "scanner needs configured `yum` in image under test. " \
+                    "%s" % str(err)
             else:
                 self.json_out["Summary"] = \
-                    "No RPM updates pending for the image."
+                    "No RPM updates pending for the image." % str(err)
             resp = []
 
         self.json_out['Scan Results']['Package Updates'] = resp

--- a/atomic_scanners/scanner-rpm-verify/Dockerfile
+++ b/atomic_scanners/scanner-rpm-verify/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos/centos:latest
+FROM registry.centos.org/centos/centos
 
 LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d/:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 

--- a/ci/tests/test_01_functional/test_03_scanner/__init__.py
+++ b/ci/tests/test_01_functional/test_03_scanner/__init__.py
@@ -149,9 +149,7 @@ class TestScanners(BaseTestCase):
         result_file = SCANNERS_RESULTFILE.get(
                 "registry.centos.org/pipeline-images/pipeline-scanner"
                 )[0]
-        # since pipeline scanner will fail to execute for containers with
-        # minimal golang executables and images without yum installed
-        self.assertFalse(self.check_if_file_exists(
+        self.assertTrue(self.check_if_file_exists(
             path=os.path.join(self.logs_dir, result_file)
         ))
 


### PR DESCRIPTION
pipeline-scanner would crash if the unexpected input is received, like not finding `/etc/os-release` or unable to open `rpmdb`. This changeset, makes scanner crashproof and reports errors accordingly. Also updated functional tests to expect the pipeline-scanner output file.