### PR TITLE
Fixes docker run command for INSTALL labels of scanners

### DIFF
--- a/atomic_scanners/container-capabilities-scanner/Dockerfile
+++ b/atomic_scanners/container-capabilities-scanner/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/centos/centos
 
-LABEL INSTALL='docker run -it --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 
 RUN yum -y update && \
     yum -y install epel-release && \

--- a/atomic_scanners/misc-package-updates/Dockerfile
+++ b/atomic_scanners/misc-package-updates/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/centos/centos
 
-LABEL INSTALL='docker run -it --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 
 RUN yum -y update && \
     yum -y install python-docker-py && \

--- a/atomic_scanners/pipeline-scanner/Dockerfile
+++ b/atomic_scanners/pipeline-scanner/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos7
 
-LABEL INSTALL='docker run -it --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 
 RUN yum -y update && yum clean all
 

--- a/atomic_scanners/scanner-rpm-verify/Dockerfile
+++ b/atomic_scanners/scanner-rpm-verify/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/centos/centos:latest
 
-LABEL INSTALL='docker run -ti --rm --privileged -v /etc/atomic.d/:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d/:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 
 # Install python-docker-py to spin up container using scan script
 RUN yum -y update && yum -y install python-docker-py && yum clean all


### PR DESCRIPTION
  atomic can't avail tty while installing atomic scanners images,
  the `docker run` command given in INSTALL label of scanner images
  needs an update, `-ti` option needs to be removed.