### PR TITLE
Takes off python-docker-py package installation from rpm-verify scanner

### DIFF
--- a/atomic_scanners/scanner-rpm-verify/Dockerfile
+++ b/atomic_scanners/scanner-rpm-verify/Dockerfile
@@ -1,10 +1,7 @@
 FROM registry.centos.org/centos/centos:latest
 
-LABEL INSTALL='docker run -ti --rm --privileged -v /etc/atomic.d/:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d/:/host/etc/atomic.d/ $IMAGE sh /install.sh'
 
-# Install python-docker-py to spin up container using scan script
-RUN yum -y update && yum -y install python-docker-py && yum clean all
+RUN yum -y update && yum clean all
 
-ADD rpm-verify /
-ADD rpm_verify.py /
-ADD install.sh /
+ADD rpm-verify rpm_verify.py install.sh /


### PR DESCRIPTION
  python-docker-py package is not needed for scanner functionality.
  Removes number of layers in ADD statement.