### PR TITLE
[DoNotMerge] Adds RHEL7 based atomic scanners' Dockerfiles

### DIFF
--- a/atomic_scanners/container-capabilities-scanner/Dockerfile.rhel7
+++ b/atomic_scanners/container-capabilities-scanner/Dockerfile.rhel7
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/rhel7
+
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+
+RUN yum -y update && \
+    yum-config-manager -q -y --enable rhel-7-server-extras-rpms && \
+    yum -y install atomic python-docker-py && \
+    yum clean all
+
+ADD container-capabilities-scanner run_scanner.py scanner.py install.sh /

--- a/atomic_scanners/container-capabilities-scanner/container-capabilities-scanner
+++ b/atomic_scanners/container-capabilities-scanner/container-capabilities-scanner
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: container-capabilities-scanner
-image_name: registry.centos.org/pipeline-images/container-capabilities-scanner
+image_name: container-capabilities-scanner:rhel7
 default_scan: check-capabilities
 custom_args: ["-v", "/var/run/docker.sock:/var/run/docker.sock", "-e", "IMAGE_NAME=$IMAGE_NAME"]
 scans: [

--- a/atomic_scanners/misc-package-updates/Dockerfile.rhel7
+++ b/atomic_scanners/misc-package-updates/Dockerfile.rhel7
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/rhel7
+
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+
+RUN yum -y update && \
+    yum-config-manager -q -y --enable rhel-7-server-extras-rpms && \
+    yum -y install python-docker-py && \
+    yum clean all
+
+ADD misc-package-updates scanner.py install.sh /

--- a/atomic_scanners/misc-package-updates/misc-package-updates
+++ b/atomic_scanners/misc-package-updates/misc-package-updates
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: misc-package-updates
-image_name: registry.centos.org/pipeline-images/misc-package-updates
+image_name: misc-package-updates:rhel7
 default_scan: pip-updates
 custom_args: ["-v", "/var/run/docker.sock:/var/run/docker.sock", "-e", "IMAGE_NAME=$IMAGE_NAME"]
 scans: [

--- a/atomic_scanners/pipeline-scanner/Dockerfile.rhel7
+++ b/atomic_scanners/pipeline-scanner/Dockerfile.rhel7
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/rhel7
+
+LABEL INSTALL='docker run  --rm --privileged -v /etc/atomic.d:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+
+RUN yum -y update && yum clean all
+
+ADD pipeline-scanner /
+ADD scanner.py /
+ADD install.sh /

--- a/atomic_scanners/pipeline-scanner/pipeline-scanner
+++ b/atomic_scanners/pipeline-scanner/pipeline-scanner
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: pipeline-scanner
-image_name: registry.centos.org/pipeline-images/pipeline-scanner
+image_name: pipeline-scanner:rhel7
 default_scan: yum-update
 scans: [
   { name: yum-update,

--- a/atomic_scanners/scanner-rpm-verify/Dockerfile.rhel7
+++ b/atomic_scanners/scanner-rpm-verify/Dockerfile.rhel7
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/rhel7
+
+LABEL INSTALL='docker run --rm --privileged -v /etc/atomic.d/:/host/etc/atomic.d/ $IMAGE sh /install.sh'
+
+# Install python-docker-py to spin up container using scan script
+RUN yum -y update && yum clean all
+
+ADD rpm-verify /
+ADD rpm_verify.py /
+ADD install.sh /

--- a/atomic_scanners/scanner-rpm-verify/rpm-verify
+++ b/atomic_scanners/scanner-rpm-verify/rpm-verify
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: rpm-verify
-image_name: registry.centos.org/pipeline-images/scanner-rpm-verify
+image_name: scanner-rpm-verify:rhel7
 default_scan: rpm-verify
 scans: [
   { name: rpm-verify,


### PR DESCRIPTION
This changeset adds `Dockerfile.rhel7` in each scanner dir.
On build host, enable `rhel-7-server-extras-rpms` repo to install `docker` RPM and the repo is also enabled during build (check `yum-config-manager` command in Dockerfiles)
```
$ subscription-manager repos --enable=rhel-7-server-extras-rpms
```
  