### PR TITLE
Shifts from using sudo to become in ansible playbook

### DIFF
--- a/provisions/group_vars/all
+++ b/provisions/group_vars/all
@@ -32,3 +32,8 @@ sentry_enabled: false
 sentry_log_level: 'WARNING'
 # sentry_dsn must be defined in hosts file if you enable sentry
 # sentry_dsn: ''
+
+# ansible playbook related configs
+ansible_become: true
+ansible_become_method: sudo  # default, but set explicitly for clarity
+ansible_become_user: root  # default, but set explicitly for clarity

--- a/provisions/main.yml
+++ b/provisions/main.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Disable requiretty in sudoers
       lineinfile:  dest=/etc/sudoers state=absent regexp="^Defaults    requiretty.*"
-      sudo: yes
+      become: true
     - name: Enable centos admin repo when EPEL is disabled
       copy: src=centos-admin.repo dest=/etc/yum.repos.d/centos-admin.repo
       when: not enable_epel
@@ -20,7 +20,7 @@
           state: permissive
     - name: Install rsync in all nodes
       yum: name=rsync state=installed
-      sudo: yes
+      become: true
   tags:
     - jenkins
     - openshift
@@ -77,13 +77,13 @@
           mode: push
           rsync_opts:
             - "{{ rsync_ssh_opts }}"
-      sudo: yes
+      become: true
     - name: Push config
       copy: src=/tmp/cccp_settings.py dest=/opt/cccp-service/container_pipeline/lib/settings.py
-      sudo: yes
+      become: true
     - name: Ensure manage.py is executable
       file: path=/opt/cccp-service/manage.py mode='g+x'
-      sudo: yes
+      become: true
       tags:
           - application
           - application/update_src

--- a/provisions/roles/ci_nfs/clients/tasks/main.yml
+++ b/provisions/roles/ci_nfs/clients/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install nfs-utils for NFS sharing
   when: setup_nfs
-  sudo: yes
+  become: true
   yum: name=nfs-utils state=present
   tags:
   - ci_nfs
@@ -9,7 +9,7 @@
 
 - name: Create NFS mount directory
   when: setup_nfs
-  sudo: yes
+  become: true
   file:
     path: /srv/pipeline-logs
     state: directory
@@ -20,7 +20,7 @@
 
 - name: Mount NFS share on the node
   when: setup_nfs
-  sudo: yes
+  become: true
   mount:
     name: /srv/pipeline-logs
     src: "{{ test_nfs_share }}"

--- a/provisions/roles/ci_nfs/server/tasks/main.yml
+++ b/provisions/roles/ci_nfs/server/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install nfs-utils for NFS sharing
   when: setup_nfs
-  sudo: yes
+  become: true
   yum: name=nfs-utils state=present
   tags:
   - ci_nfs
@@ -9,7 +9,7 @@
 
 - name: Install firewalld for opening NFS ports
   when: setup_nfs
-  sudo: yes
+  become: true
   yum: name=firewalld state=present
   tags:
   - ci_nfs
@@ -17,7 +17,7 @@
 
 - name: Start firewalld service
   when: setup_nfs
-  sudo: yes
+  become: true
   service: name=firewalld enabled=yes state=started
   tags:
   - ci_nfs
@@ -25,7 +25,7 @@
 
 - name: Create NFS mount directory
   when: setup_nfs
-  sudo: yes
+  become: true
   file:
     path: /nfsshare
     state: directory
@@ -36,7 +36,7 @@
 
 - name: Add entry in /etc/exports to configure NFS mount
   when: setup_nfs
-  sudo: yes
+  become: true
   lineinfile:
     destfile: /etc/exports
     line: "/nfsshare (rw,sync,no_subtree_check,all_squash,anonuid=0,anongid=0)"
@@ -46,7 +46,7 @@
 
 - name: ensure iptables is configured to allow TCP ports 2049
   when: setup_nfs
-  sudo: yes
+  become: true
   firewalld: port=2049/tcp zone=public permanent=true state=enabled immediate=yes
   tags:
   - ci_nfs
@@ -54,7 +54,7 @@
 
 - name: Ensure iptables is configured to allow TCP ports 111
   when: setup_nfs
-  sudo: yes
+  become: true
   firewalld: port=111/tcp zone=public permanent=true state=enabled immediate=yes
   tags:
   - ci_nfs
@@ -62,7 +62,7 @@
 
 - name: Start and Enable NFS service
   when: setup_nfs
-  sudo: yes
+  become: true
   service: name=nfs-server enabled=yes state=started
   tags:
   - ci_nfs

--- a/provisions/roles/cleanup/jenkins/master/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/master/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Stop jenkins systemd service
-  sudo: yes
+  become: true
   service: name=jenkins state=stopped
 
 - name: Remove the virtual environment directories
-  sudo: yes
+  become: true
   file: path=/opt/cccp-service state=absent
 
 - name: Remove images with no name or tag
-  sudo: yes
+  become: true
   ignore_errors: yes
   shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
+++ b/provisions/roles/cleanup/jenkins/slave/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Stop and remove worker containers
-  sudo: yes
+  become: true
   docker_container:
     name: "{{ item }}"
     state: absent
@@ -12,10 +12,10 @@
     - delivery-worker
 
 - name: Remove /opt/cccp-service directory
-  sudo: yes
+  become: true
   file: path=/opt/cccp-service state=absent
 
 - name: Remove images with no name or tag
-  sudo: yes
+  become: true
   ignore_errors: yes
   shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/cleanup/openshift/tasks/main.yml
+++ b/provisions/roles/cleanup/openshift/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
 - name: Remove all running and exited other containers
-  sudo: yes
+  become: true
   shell: docker rm -f `docker ps -a -q`
   ignore_errors: yes
 
 - name: Remove all images
-  sudo: yes
+  become: true
   shell: docker rmi -f `docker images -a -q`
   ignore_errors: yes
 
 - name: Remove mounts
-  sudo: yes
+  become: true
   shell: for f in `mount | grep origin | cut -f3 -d\ `; do umount $f ; done
   ignore_errors: yes
 
 - name: Remove /var/lib/origin/* directory contents
-  sudo: yes
+  become: true
   shell: rm -rf /var/lib/origin/*
 
 - name: Remove images with no name or tag
-  sudo: yes
+  become: true
   ignore_errors: yes
   shell: docker rmi $(docker images -f "dangling=true" -q)

--- a/provisions/roles/cleanup/scanner/tasks/main.yml
+++ b/provisions/roles/cleanup/scanner/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: Remove all containers
-  sudo: yes
+  become: true
   shell: docker rm -f `docker ps -a -q`
 
 - name: Remove /var/lib/atomic/* directory contents
-  sudo: yes
+  become: true
   shell: rm -rf /var/lib/atomic/*
 
 - name: Remove /var/lib/docker/volumes/* directory contents
-  sudo: yes
+  become: true
   shell: rm -rf /var/lib/docker/volumes/*
 
 - name: Remove dangling images
-  sudo: yes
+  become: true
   ignore_errors: yes
   shell: docker rmi -f `docker images -q -f dangling=true`
 
 - name: Remove dangling volumes
-  sudo: yes
+  become: true
   ignore_errors: yes
   shell: docker volume rm `docker volume ls -q -f dangling=true`

--- a/provisions/roles/db/tasks/main.yml
+++ b/provisions/roles/db/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if NFS backup directory exists on node
-  sudo: yes
+  become: true
   stat:
     path: '{{db_backup_nfs_path}}'
   register: nfs_dir_mounted
@@ -8,7 +8,7 @@
   tags: db
 
 - name: Fail if NFS share is not mounted on node for db backup
-  sudo: yes
+  become: true
   fail:
     msg: "NFS share is not mounted on node for db backup."
   when:
@@ -21,20 +21,20 @@
     path: '{{ db_local_volume }}'
     state: directory
     mode: 0766
-  sudo: yes
+  become: true
   tags: db
 
 - name: Set ACL for local dir for volumen sharing
-  sudo: yes
+  become: true
   shell: "setfacl -m u:{{ postgresql_uid }}:-wx {{ db_local_volume }}"
   tags: db
 
 - name: Reload docker systemd service
-  sudo: yes
+  become: true
   systemd: name=docker state=reloaded
 
 - name: Start Docker service
-  sudo: yes
+  become: true
   systemd: name=docker state=started enabled=yes
 
 - name: Pull CentOS postgres container
@@ -43,7 +43,7 @@
       tag: latest
       state: present
       force: yes
-  sudo: yes
+  become: true
   tags: db
 
 - name: Run postgres container
@@ -60,7 +60,7 @@
           POSTGRESQL_DATABASE: '{{ db_name }}'
       state: started
       restart_policy: on-failure
-  sudo: yes
+  become: true
   tags: db
 
 - name: Wait for 20 seconds for the db to come up
@@ -69,14 +69,14 @@
   tags: db
 
 - name: Copy cron script to have postgresql db backups
-  sudo: yes
+  become: true
   template: src=cccp_db_pg_dump_cron.sh.j2 dest=/root/cccp_db_pg_dump_cron.sh mode=0755
   tags:
     - db
     - cron
 
 - name: Cron job for postgresql db backups hourly
-  sudo: yes
+  become: true
   cron:
       name: "Postgresql cccp db hourly backup"
       job: "/root/cccp_db_pg_dump_cron.sh"
@@ -86,14 +86,14 @@
     - cron
 
 - name: Copy cron script to check if the pg-dump exported latest tar file is readable
-  sudo: yes
+  become: true
   template: src=cron_cccp_db_read_check.sh.j2 dest=/root/cron_cccp_db_read_check.sh mode=0755
   tags:
     - db
     - cron
 
 - name: Cron job for postgresql db backups hourly
-  sudo: yes
+  become: true
   cron:
       name: "Postgresql cccp database tar readability check"
       job: "/root/cron_cccp_db_read_check.sh"
@@ -103,14 +103,14 @@
     - cron
 
 - name: Copy cron script to delete old pg_dump tar files
-  sudo: yes
+  become: true
   template: src=cron_delete_pg_dump_tars.sh.j2 dest=/root/cron_delete_pg_dump_tars.sh mode=0755
   tags:
     - db
     - cron
 
 - name: Cron job to delete old pg_dump tar files daily
-  sudo: yes
+  become: true
   cron:
       name: "Cron to delete old pg_dump tar files daily"
       job: "/root/cron_delete_pg_dump_tars.sh"

--- a/provisions/roles/django/tasks/main.yml
+++ b/provisions/roles/django/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: Enable epel
   yum: name=epel-release state=installed
-  sudo: yes
+  become: true
   tags: django
 
 - name: Install pip
   yum: name=python-pip state=installed
-  sudo: yes
+  become: true
   tags: django
 
 - name: Install Django
   pip: name=django version=1.11.2
-  sudo: yes
+  become: true
   tags: django
 
 - name: Install latest docker and python-docker-py packages
   yum: name={{ item }} state=latest
-  sudo: yes
+  become: true
   with_items:
       - docker
       - python-docker-py
@@ -24,20 +24,20 @@
 
 - name: Install postgresql-devel
   yum: name=postgresql-devel state=installed
-  sudo: yes
+  become: true
   tags: django
 
 - name: Install psycopg2
   pip: name=psycopg2 version=2.7.3
-  sudo: yes
+  become: true
   tags: django
 
 - name: Install raven
   pip: name=raven version=6.5.0
-  sudo: yes
+  become: true
   tags: django
 
 - name: Ensure docker group exists
   group: name=docker state=present
-  sudo: yes
+  become: true
   tags: django

--- a/provisions/roles/jenkins/master/tasks/install.yml
+++ b/provisions/roles/jenkins/master/tasks/install.yml
@@ -16,7 +16,7 @@
   yum: name=jenkins-2.67-1.1 state=present
 
 - name: Reload jenkins systemd service
-  sudo: yes
+  become: true
   systemd: name=jenkins state=reloaded
 
 - name: Ensure jenkins is enabled and started

--- a/provisions/roles/jenkins/master/tasks/logrotate.yml
+++ b/provisions/roles/jenkins/master/tasks/logrotate.yml
@@ -1,8 +1,8 @@
 ---
 - name: Enable logrotate to run hourly
   file: src=/etc/cron.daily/logrotate dest=/etc/cron.hourly/logrotate state=link force=yes
-  sudo: yes
+  become: true
 
 - name: Enable logrotate for /srv/pipeline-logs/cccp.log
   template: src=cccp.logrotate.j2 dest=/etc/logrotate.d/cccp
-  sudo: yes
+  become: true

--- a/provisions/roles/jenkins/master/tasks/main.yml
+++ b/provisions/roles/jenkins/master/tasks/main.yml
@@ -5,7 +5,7 @@
 # Stop Jenkins so no files are overriden by a running Jenkins instance
 - name: Stop jenkins before configuration
   service: name=jenkins state=stopped
-  sudo: yes
+  become: true
   tags:
   - jenkins/master
 
@@ -16,7 +16,7 @@
 # Start Jenkins again
 - name: Start jenkins
   service: name=jenkins state=started
-  sudo: yes
+  become: true
   tags:
   - jenkins/master
 

--- a/provisions/roles/jenkins/slave/tasks/setup_worker.yml
+++ b/provisions/roles/jenkins/slave/tasks/setup_worker.yml
@@ -11,14 +11,14 @@
     line: 'ADD_REGISTRY="--add-registry {{ public_registry }}:5000 --add-registry registry.centos.org"'
 
 - name: Reload docker systemd service
-  sudo: yes
+  become: true
   systemd: name=docker state=reloaded
 
 - name: Restart Docker
   systemd: name=docker state=restarted enabled=yes
 
 - name: Build container-pipeline image
-  sudo: yes
+  become: true
   docker_image:
     state: present
     force: yes
@@ -96,7 +96,7 @@
       - application
 
 - name: Reload Dockerfile linter worker systemd service
-  sudo: yes
+  become: true
   systemd: name=cccp-dockerfile-lint-worker daemon_reload=yes
   tags:
       - application

--- a/provisions/roles/monitoring/sentry/tasks/initialize.yml
+++ b/provisions/roles/monitoring/sentry/tasks/initialize.yml
@@ -1,13 +1,13 @@
 ---
 - name: Create secret key if not already there
   shell: docker run --rm {{ sentry_container_image }} config generate-secret-key > sentry.key
-  sudo: yes
+  become: true
   run_once: true
 
 - name: Load sentry secret key into vars
   shell: cat sentry.key
   register: secret_result
-  sudo: yes
+  become: true
 
 - name: Run sentry upgrade
   shell: >
@@ -19,7 +19,7 @@
       --link sentry-postgres:postgres
       --link sentry-redis:redis
       {{ sentry_container_image }} upgrade --noinput
-  sudo: yes
+  become: true
 
 - name: Create super user for sentry
   shell: >
@@ -32,4 +32,4 @@
       --link sentry-redis:redis
       {{ sentry_container_image }} createuser --email {{ sentry_admin_email }} --password {{ sentry_admin_password }} --superuser --no-input
   ignore_errors: yes
-  sudo: yes
+  become: true

--- a/provisions/roles/monitoring/sentry/tasks/main.yml
+++ b/provisions/roles/monitoring/sentry/tasks/main.yml
@@ -2,16 +2,16 @@
 - name: Ensure redis container image is present
   docker_image:
       name: registry.centos.org/centos/redis:latest
-  sudo: yes
+  become: true
 
 - name: Copy redis conf file
   shell: >
       docker run --rm --entrypoint cat registry.centos.org/centos/redis:latest /redis-master/redis.conf > {{ ansible_env.HOME }}/redis.conf
-  sudo: yes
+  become: true
 
 - name: Disable redis protection-mode in conf
   lineinfile: dest="{{ ansible_env.HOME }}/redis.conf" regexp="protected-mode" line="protected-mode no"
-  sudo: yes
+  become: true
 
 - name: Run sentry redis container
   docker_container:
@@ -23,7 +23,7 @@
           - "6379:6379"
       volumes:
           - "{{ ansible_env.HOME }}/redis.conf:/redis-master/redis.conf"
-  sudo: yes
+  become: true
 
 - name: Run sentry postgres container
   docker_container:
@@ -35,12 +35,12 @@
           POSTGRESQL_DATABASE: '{{ sentry_db_name }}'
       volumes:
           - sentry-pg-data:/var/lib/pgsql/data
-  sudo: yes
+  become: true
 
 - name: Pull sentry image
   docker_image:
       name: {{ sentry_container_image }}
-  sudo: yes
+  become: true
 
 - include: initialize.yml
   tags:
@@ -50,7 +50,7 @@
 - name: Load sentry secret key into vars
   shell: cat sentry.key
   register: secret_result
-  sudo: yes
+  become: true
 
 - name: Run sentry server
   docker_container:
@@ -66,7 +66,7 @@
           SENTRY_DB_NAME: '{{ sentry_db_name }}'
           SENTRY_DB_USER: '{{ sentry_db_user }}'
           SENTRY_DB_PASSWORD: '{{ sentry_db_password }}'
-  sudo: yes
+  become: true
 
 - name: Run sentry cron
   docker_container:
@@ -81,7 +81,7 @@
           SENTRY_DB_USER: '{{ sentry_db_user }}'
           SENTRY_DB_PASSWORD: '{{ sentry_db_password }}'
       command: run cron
-  sudo: yes
+  become: true
 
 - name: Run sentry worker
   docker_container:
@@ -96,4 +96,4 @@
           SENTRY_DB_USER: '{{ sentry_db_user }}'
           SENTRY_DB_PASSWORD: '{{ sentry_db_password }}'
       command: run worker
-  sudo: yes
+  become: true

--- a/provisions/roles/nginx/tasks/main.yml
+++ b/provisions/roles/nginx/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
   - name: Enable epel repo
-    sudo: yes
+    become: true
     yum: name=epel-release state=present
     when: enable_epel
     tags:
@@ -8,14 +8,14 @@
       - jenkins/slave
 
   - name: Install nginx
-    sudo: yes
+    become: true
     yum: name=nginx state=present
     tags:
       - nginx
       - jenkins/slave
 
   - name: Copy SSL certs
-    sudo: yes
+    become: true
     template: src={{ item.src }} dest={{ item.dest }}
     with_items:
         - { src: "{{ ssl_key_template }}", dest: "{{ ssl_key_file }}" }
@@ -27,21 +27,21 @@
 
 
   - name: Copy nginx conf for CentOS registry
-    sudo: yes
+    become: true
     template: src={{ nginx_conf_template }} dest=/etc/nginx/conf.d/{{ nginx_conf_filename }}
     tags:
       - nginx
       - jenkins/slave
 
   - name: Reload nginx systemd service
-    sudo: yes
+    become: true
     systemd: name=nginx state=reloaded
     tags:
       - nginx
       - jenkins/slave
 
   - name: restart nginx
-    sudo: yes
+    become: true
     service: name=nginx state=restarted enabled=yes
     tags:
       - nginx

--- a/provisions/roles/openshift/tasks/install.yml
+++ b/provisions/roles/openshift/tasks/install.yml
@@ -16,7 +16,7 @@
       - python-docker-py
 
 - name: Reload docker systemd service
-  sudo: yes
+  become: true
   systemd: name=docker state=reloaded
 
 - name: Start Docker service

--- a/provisions/roles/openshift/tasks/setup_mailservice.yml
+++ b/provisions/roles/openshift/tasks/setup_mailservice.yml
@@ -14,7 +14,7 @@
   file: path=/srv/pipeline-logs/cccp.log state=touch
 
 - name: Stop mail-server container
-  sudo: yes
+  become: true
   ignore_errors: true
   docker_container:
     name: mail-server
@@ -28,7 +28,7 @@
       replace="LOG_LEVEL = '{{ log_level }}'"
 
 - name: Build mail-server container image
-  sudo: yes
+  become: true
   docker_image:
     name: mail-server
     path: "/opt/cccp-service"

--- a/provisions/roles/registry/tasks/main.yml
+++ b/provisions/roles/registry/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
 - name: Install Docker distribution
   yum: name=docker-distribution state=present
-  sudo: yes
+  become: true
   tags:
     - registry
     - jenkins/slave
 
 - name: Enable and run Docker Distribution
   service: name=docker-distribution enabled=yes state=started
-  sudo: yes
+  become: true
   tags:
     - registry
     - jenkins/slave
 
 - name: Run UI registry container.
-  sudo: yes
+  become: true
   docker_container:
       image: registry.centos.org/pipeline-images/reg:latest
       name: registry-ui

--- a/provisions/roles/repo_tracking/tasks/main.yml
+++ b/provisions/roles/repo_tracking/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Enable epel
   yum: name=epel-release state=installed
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Ensure that user jenkins is included in docker group
   user: name=jenkins groups=docker append=yes
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Enable Docker Registry
@@ -20,16 +20,16 @@
     dest=/etc/sysconfig/docker
     regexp="^\s*OPTIONS=.*"
     replace="OPTIONS='--selinux-enabled --log-driver=journald --signature-verification=false -H localhost:2367 -H unix:///var/run/docker.sock'"
-  sudo: yes
+  become: true
 
 - name: Enable and start Docker service
   service: name=docker state=started
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Install fedmsg and utils
   yum: name={{ item }} state=installed
-  sudo: yes
+  become: true
   with_items:
     - fedmsg
     - fedmsg-relay
@@ -40,17 +40,17 @@
       dest: /etc/fedmsg.d/ssl.py
       regexp: "validate_signatures=True"
       replace: "validate_signatures=False"
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Ensure jenkinsbuilder is a package
   file: path=/opt/cccp-service/jenkinsbuilder/__init__.py state=touch
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Ensure repo data dir exists
   file: path=/opt/cccp-service/container_pipeline/tracking/data state=directory
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Initialize for creating DB tables.
@@ -58,7 +58,7 @@
   ignore_errors: yes
   retries: 5
   delay: 10
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Create DB tables
@@ -66,36 +66,36 @@
   ignore_errors: yes
   retries: 5
   delay: 10
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Copy fedmsg conf
   copy:
       src: "{{ role_path }}/../../../fedmsg.d/container_pipeline.py"
       dest: "/etc/fedmsg.d/container_pipeline.py"
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Copy empty fedmsg endpoints conf
   copy:
       src: fedmsg_endpoints.py
       dest: /etc/fedmsg.d/endpoints.py
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Start fedmsg-relay
   service: name=fedmsg-relay state=restarted enabled=True
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Ensure jenkins user can write to log file
   file: path=/srv/pipeline-logs/cccp.log state=file owner=jenkins
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Copy jenkins job template
   template: src=jobs.yml.j2 dest="{{ ansible_env.HOME }}/repo_tracking_job.yml"
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Ensure jenkins user is owner of src dir
@@ -103,7 +103,7 @@
       path: /opt/cccp-service/
       owner: jenkins
       recurse: yes
-  sudo: yes
+  become: true
   tags: repo_tracking
 
 - name: Create jenkins jobs
@@ -116,13 +116,13 @@
       - cccp_pkgupdatelistener.service
       - cccp_triggerbuilds.service
       - cccp_imagescanner.service
-  sudo: yes
+  become: true
   tags: repo_tracking
   register: service_files_updated
 
 - name: systemctl daemon-reload
   shell: systemctl daemon-reload
-  sudo: yes
+  become: true
   when: service_files_updated
 
 - name: Enable and start services
@@ -131,5 +131,5 @@
       - cccp_pkgupdatelistener
       - cccp_triggerbuilds
       - cccp_imagescanner
-  sudo: yes
+  become: true
   tags: repo_tracking

--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: Install Atomic
   yum: name=atomic state=present
-  sudo: yes
+  become: true
   tags: scanner
 
 - name: Install docker
   yum: name=docker state=latest
-  sudo: yes
+  become: true
   tags: scanner
 
 - name: Start and Enable docker
   systemd: name=docker enabled=yes state=started
-  sudo: yes
+  become: true
   tags: scanner
 
 - name: Enable Docker Host socket
@@ -73,7 +73,7 @@
       - scanner
       - application
 - name: Reload scan worker systemd service
-  sudo: yes
+  become: true
   systemd: name=cccp-scan-worker daemon_reload=yes
   tags:
       - scanner


### PR DESCRIPTION
Since using `sudo` in ansible playbook will be deprecated at some point in favor of `become` and this avoids warnings printed per deployment for CI, devlcoud, staging and prod environments.

With this change in place, run
```
# cleanup
$ ansible-playbook -i provisions/hosts provisions/cleanup.yml

# deployment
$ ansible-playbook -i provisions/hosts provisions/main.yml
```

 Notice, we don't need extra flag `-s`. Also check the explicit mention of flags in `group_vars/all` file.