### PR TITLE
Remove rsync_ssh_opts from group_vars/all

### DIFF
--- a/provisions/group_vars/all
+++ b/provisions/group_vars/all
@@ -9,8 +9,6 @@ test: False
 # Whether to enable epel repo for packages
 enable_epel: True
 
-rsync_ssh_opts: ''
-
 # database related configurations
 db_user: cccp
 db_name: cccp

--- a/provisions/hosts.sample
+++ b/provisions/hosts.sample
@@ -33,6 +33,7 @@ public_registry=jenkins-slave
 intranet_registry=jenkins-slave:5000
 # configure beanstalkd server node
 beanstalk_server=open-shift
+rsync_ssh_opts=""
 db_host=jenkins-master
 
 


### PR DESCRIPTION
If specified within group_vars/all, rsync_ssh_opts will override
whatever value is set in the "hosts" file.