### PR TITLE
Fixes cleaning up created containers upon failure, fixes processing output

### DIFF
--- a/atomic_scanners/misc-package-updates/scanner.py
+++ b/atomic_scanners/misc-package-updates/scanner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from datetime import datetime
+from time import sleep
 import docker
 import json
 import logging
@@ -152,12 +153,18 @@ def create_container(client, image, ep, cmd):
     """
     response = ""
     try:
+        # create the container
         container = client.create_container(
-                image=image,
-                entrypoint=ep,
-                command=cmd
+            image=image,
+            entrypoint=ep,
+            command=cmd
         )
-        response = client.start(container=container.get("Id"))
+        # start the container
+        client.start(container=container.get("Id"))
+        # pause for 10 seconds for package manager to collect data
+        sleep(10)
+        # get the logs from container
+        response = client.logs(container=container.get("Id"))
     except Exception as e:
         logger.log(
             level=logging.ERROR,
@@ -176,23 +183,23 @@ try:
     # Check for pip updates
     if cli_arg == "pip":
         response = create_container(
-                client, IMAGE_NAME,
-                ep="/usr/bin/pip",
-                cmd="list --outdated")
+            client, IMAGE_NAME,
+            ep="/usr/bin/pip",
+            cmd="list --outdated")
 
     # Check for rubygem updates
     elif cli_arg == "gem":
         response = create_container(
-                client, IMAGE_NAME,
-                ep="/usr/bin/gem",
-                cmd="outdated")
+            client, IMAGE_NAME,
+            ep="/usr/bin/gem",
+            cmd="outdated")
 
     # Check for npm updates
     elif cli_arg == "npm":
         response = create_container(
-                client, IMAGE_NAME,
-                ep="/usr/bin/npm",
-                cmd="outdated -g")
+            client, IMAGE_NAME,
+            ep="/usr/bin/npm",
+            cmd="outdated -g")
 
 except Exception as e:
     logger.log(

--- a/atomic_scanners/misc-package-updates/scanner.py
+++ b/atomic_scanners/misc-package-updates/scanner.py
@@ -135,7 +135,7 @@ def template_json_data(scan_type):
     current_time = datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
     json_out = {
         "Start Time": current_time,
-        "Successful": "",
+        "Successful": False,
         "Scan Type": scan_type + "-updates",
         "UUID": UUID,
         "CVE Feed Last Updated": "NA",
@@ -171,8 +171,8 @@ def create_container(client, image, ep, cmd):
 
 
 json_out = template_json_data(cli_arg)
+response = ""
 try:
-    response = ""
     # Check for pip updates
     if cli_arg == "pip":
         response = create_container(
@@ -200,7 +200,7 @@ except Exception as e:
         msg="Scanner failed: {}".format(e)
     )
 
-else:
+finally:
     if not response or binary_does_not_exist(response):
         json_out["Scan Results"] = \
             "Could not find {} executable in the image".format(cli_arg)


### PR DESCRIPTION
Fixes #544:
 - Ensure created container by scanner is removed before exiting
 - Ensure response processing is exception proof
 - Removes volume associated with container while removing container
 - Don't create container in daemon mode from image_under test, rather create individual containers per scan type