### PR TITLE
Fixes rpm_verify scanner wrapper to add error message upon failure

### DIFF
--- a/container_pipeline/scanners/rpm_verify.py
+++ b/container_pipeline/scanners/rpm_verify.py
@@ -80,6 +80,7 @@ class ScannerRPMVerify(object):
         data = {}
         data["scanner_name"] = self.scanner_name
         # TODO: More verifcation and validation on the data
-        data["msg"] = json_data["Summary"]
+        data["msg"] = json_data.get(
+            "Summary", "Failed to run the scanner.")
         data["logs"] = json_data
         return data


### PR DESCRIPTION
  Fixes #543: Earlier the report wrapper would expect `Summary` key
  from scanners' output, however there are cases, where scanner could
  fail and we need to have sensible defaults.