### PR TITLE
Uniforms scanners output filename to a pattern

### DIFF
--- a/atomic_scanners/misc-package-updates/scanner.py
+++ b/atomic_scanners/misc-package-updates/scanner.py
@@ -227,7 +227,7 @@ finally:
 output_dir = os.path.join(OUTDIR, UUID)
 os.makedirs(output_dir)
 
-output_file_relative = "image_scan_results.json"
+output_file_relative = "misc_package_updates_scanner_results.json"
 
 output_file_absoulte = os.path.join(output_dir, output_file_relative)
 

--- a/atomic_scanners/pipeline-scanner/scanner.py
+++ b/atomic_scanners/pipeline-scanner/scanner.py
@@ -57,7 +57,7 @@ class ScanImageRootfs(object):
         self.pretty_name = None
 
         # output file for the scan results
-        op_file = "image_scan_results.json"
+        op_file = "pipeline_scanner_results.json"
         self.op_file = os.path.join(self.out_path, op_file)
 
         # json data for the output

--- a/atomic_scanners/scanner-rpm-verify/rpm_verify.py
+++ b/atomic_scanners/scanner-rpm-verify/rpm_verify.py
@@ -56,9 +56,7 @@ class RPMVerify(object):
         self.scan_type = "RPM Verify scan for finding tampered files."
         self.scanner = "scanner-rpm-verify"
 
-        self.result_filename = os.path.join(
-            self.out_path,
-            self.__class__.__name__ + ".json")
+        self.result_filename = "rpm_verify_scanner_results.json"
 
         # json data for the output
         self.json_out = self.template_json_data(

--- a/container_pipeline/lib/default_settings.py
+++ b/container_pipeline/lib/default_settings.py
@@ -171,27 +171,17 @@ SCANNERS_OUTPUT = {
         "image_scan_results.json"
     ],
     "registry.centos.org/pipeline-images/misc-package-updates": [
-        "image_scan_results.json"
+        "misc_package_updates_scanner_results.json"
     ],
     "registry.centos.org/pipeline-images/scanner-rpm-verify": [
-        "RPMVerify.json"
+        "rpm_verify_scanner_results.json"
     ],
     "registry.centos.org/pipeline-images/container-capabilities-scanner": [
         "container_capabilities_scanner_results.json"
     ]
 }
-SCANNERS_RESULTFILE = {
-    "registry.centos.org/pipeline-images/pipeline-scanner": [
-        "pipeline_scanner_results.json"],
-    "registry.centos.org/pipeline-images/misc-package-updates": [
-        "misc_package_updates_scanner_results.json"],
-    "registry.centos.org/pipeline-images/scanner-rpm-verify": [
-        "RPMVerify_scanner_results.json"],
-    "registry.centos.org/pipeline-images/container-capabilities-scanner": [
-        "container-capabilities-results.json"
-    ]
+SCANNERS_RESULTFILE = SCANNERS_OUTPUT.copy()
 
-}
 SCANNERS_STATUS_FILE = "scanners_status.json"
 
 LINTER_RESULT_FILE = "linter_results.txt"


### PR DESCRIPTION
Each atomic scanner will now export result file with name `<scanner_name>_results.json`, earlier scanners 
were exporting result filenames in different ways.