### PR TITLE
Disable registry cleanup

### DIFF
--- a/provisions/roles/jenkins/slave/tasks/cleanup_registry.yml
+++ b/provisions/roles/jenkins/slave/tasks/cleanup_registry.yml
@@ -3,5 +3,6 @@
 - name: Copy cron script to clean up mismatched tags from registry
   template: src=cron_delete_index_mismatch.sh.j2 dest=/root/cron_delete_index_mismatch.sh mode=0755
 
-- name: Add cronjob to clean up mismatched tags from registry
-  cron: name="To delete mismatched containers from registry" hour="*/6" job=/root/cron_delete_index_mismatch.sh
+# TODO: Uncomment after fixing #551
+# - name: Add cronjob to clean up mismatched tags from registry
+#   cron: name="To delete mismatched containers from registry" hour="*/6" job=/root/cron_delete_index_mismatch.sh


### PR DESCRIPTION
This fix is meant to prevent automated image deletion from internal registry and r.c.o till the time we fix #551 