### PR TITLE
[WIP]Sets working NVRA of atomic package in provisioning as latest being broken

### DIFF
--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Atomic
-  yum: name=atomic state=present
+  yum: name=atomic-1.20.1-9.git436cf5d.el7.centos.x86_64 state=present
   become: true
   tags: scanner
 


### PR DESCRIPTION
  Fixes #567: Latest atomic-1.22.1 has broken the atomic mount functionality,
  breaking scanner functionality.
  Stick to working version atomic-1.20.1 and sets explicitly in provisioning
  scripts.