### PR TITLE
Uses devicemapper storage driver for devcloud environments

### DIFF
--- a/provisions/roles/scanner/tasks/main.yml
+++ b/provisions/roles/scanner/tasks/main.yml
@@ -33,6 +33,15 @@
       state: permissive
   tags: scanner
 
+- name: Use devicemapper storage option for docker
+  replace: >
+    dest=/etc/sysconfig/docker-storage
+    regexp="^#*\s*DOCKER_STORAGE_OPTIONS=.*"
+    replace="DOCKER_STORAGE_OPTIONS='--storage-driver devicemapper'"
+  become: true
+  when: deployment != "production" or deployment != "pre-prod" or deployment != "staging"
+  tags: scanner
+
 - name: Restart Docker
   systemd: name=docker state=restarted enabled=yes
   tags: scanner


### PR DESCRIPTION
  Fixes #567: We were using default storage driver overlay2 on devcloud
  environment, causing non writable mounts for pipeline-scanner.
  This changeset updates provisioning scripts to use devicemapper as
  storage driver when deployment environment is not in [production, pre-prod, staging].