### PR TITLE
Print data being put to tube before it's put in weekly scan

### DIFF
--- a/jenkinsbuilder/weekly-scan.py
+++ b/jenkinsbuilder/weekly-scan.py
@@ -108,6 +108,7 @@ for f in files:
             "uuid": job_uuid
         }
 
+        print ("Putting data on master_tube: {}".format(data))
         job = bs.put(json.dumps(data))
         # Initializing Database entries
         project = Project.objects.get(


### PR DESCRIPTION
This is to ensure that if anything breaks during weekly scan, we know what project it failed for. For example, if database interaction failed with project not found error, it would log what project was it searching for in the first place.