### PR TITLE
Rewiring index ci to run the new validations.

### DIFF
--- a/ci/cccp_ci_container_index.sh
+++ b/ci/cccp_ci_container_index.sh
@@ -6,8 +6,11 @@ sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
 ssh_cmd="ssh $sshopts $CICO_hostname"
 $ssh_cmd "yum -y install epel-release && yum -y install rsync git PyYAML python-networkx"
 rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-$ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
-$ssh_cmd /usr/bin/python container-pipeline-service/testindex/__init__.py  -vi payload/index.d
+#$ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
+$ssh_cmd git clone https://github.com/mohammedzee1000/container-pipeline-service.git
+$ssh_cmd git fetch --all
+$ssh_cmd git checkout origin/index_ci_refac_6
+$ssh_cmd /usr/bin/python container-pipeline-service/ci/container_index/run.py  -vi ./payload
 rtn_code=$?
 cico node done $CICO_ssid
 exit $rtn_code

--- a/ci/cccp_ci_container_index.sh
+++ b/ci/cccp_ci_container_index.sh
@@ -7,7 +7,7 @@ ssh_cmd="ssh $sshopts $CICO_hostname"
 $ssh_cmd "yum -y install epel-release && yum -y install rsync git PyYAML python-networkx"
 rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
 $ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
-$ssh_cmd /usr/bin/python container-pipeline-service/ci/container_index/run.py  -vi ./payload
+$ssh_cmd PYTHONPATH="`pwd`/container-pipeline-service" /usr/bin/python container-pipeline-service/ci/container_index/run.py  -vi ./payload
 rtn_code=$?
 cico node done $CICO_ssid
 exit $rtn_code

--- a/ci/cccp_ci_container_index.sh
+++ b/ci/cccp_ci_container_index.sh
@@ -6,10 +6,7 @@ sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
 ssh_cmd="ssh $sshopts $CICO_hostname"
 $ssh_cmd "yum -y install epel-release && yum -y install rsync git PyYAML python-networkx"
 rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-#$ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
-$ssh_cmd git clone https://github.com/mohammedzee1000/container-pipeline-service.git
-$ssh_cmd git fetch --all
-$ssh_cmd git checkout origin/index_ci_refac_6
+$ssh_cmd git clone https://github.com/CentOS/container-pipeline-service.git 
 $ssh_cmd /usr/bin/python container-pipeline-service/ci/container_index/run.py  -vi ./payload
 rtn_code=$?
 cico node done $CICO_ssid


### PR DESCRIPTION
This is for testing purposes, and another patch will be needed once new index ci is merged into master.
This uses index ci residing at https://github.com/mohammedzee1000/container-pipeline-service/tree/index_ci_refac_6/ci/container_index