### PR TITLE
Setting pythonpath before running the CI.

### DIFF
--- a/ci/job.yml
+++ b/ci/job.yml
@@ -10,7 +10,7 @@
     name: centos-container-pipeline-service-ci-builder-tests
     builders:
         - shell: |
-            python ./ci/cccp_ci.py
+            PYTHONPATH="`pwd`" python ./ci/cccp_ci.py
 
 - builder:
     name: centos-container-pipeline-service-ci-cleanup-builders


### PR DESCRIPTION
The pythonpath needs to be set to root of service code
or imports will fail.