### PR TITLE
Fixing index CI to skip jobid batch for library and desired tag no longer checks for string

### DIFF
--- a/ci/container_index/lib/checks/schema_validation.py
+++ b/ci/container_index/lib/checks/schema_validation.py
@@ -95,7 +95,7 @@ class JobIDValidator(StringFieldValidator):
         self.message.title = "Job ID Validation"
 
 
-class DesiredTagValidator(StringFieldValidator):
+class DesiredTagValidator(BasicSchemaValidator):
     """
     Checks the formatting of the desired-tag field of data.
     """
@@ -105,6 +105,12 @@ class DesiredTagValidator(StringFieldValidator):
             validation_data, file_name)
         self.field_name = FieldKeys.DESIRED_TAG
         self.message.title = "Desired Tag Validation"
+
+    def _extra_validation(self):
+        data = str(self.validation_data.get(self.field_name))
+        if len(data) == 0:
+            self._invalidate("Desired tag cannot be a zero length string")
+            return
 
 
 class GitURLValidator(StringFieldValidator):

--- a/ci/container_index/lib/checks/value_validation.py
+++ b/ci/container_index/lib/checks/value_validation.py
@@ -129,7 +129,8 @@ class JobIDMatchesIndex(CCCPYamlValidator):
         app_id = self.validation_data.get(FieldKeys.APP_ID)
         job_id = self.validation_data.get(FieldKeys.JOB_ID)
         if app_id and job_id:
-            if app_id == "centos" and job_id == "centos":
+            if ((app_id == "centos" or app_id == "library")
+               and job_id == "centos"):
                 self._warn(
                     "CentOS Base image detected, skipping for now until fix is"
                     " done to repository"

--- a/ci/tests/test_00_unit/test_05_index_ci/test_00_schema_validation/test_05_desired_tag_validation/__init__.py
+++ b/ci/tests/test_00_unit/test_05_index_ci/test_00_schema_validation/test_05_desired_tag_validation/__init__.py
@@ -28,13 +28,13 @@ class DesiredTagValidationTests(IndexCIBase):
                 DUMMY_INDEX_FILE
             ).validate().success
         )
-
-    def test_03_validation_fails_desired_tag_not_string(self):
-        self.assertFalse(
-            schema_validation.DesiredTagValidator(
-                {
-                    FieldKeys.DESIRED_TAG: 1
-                },
-                DUMMY_INDEX_FILE
-            ).validate().success
-        )
+    #
+    # def test_03_validation_fails_desired_tag_not_string(self):
+    #     self.assertFalse(
+    #         schema_validation.DesiredTagValidator(
+    #             {
+    #                 FieldKeys.DESIRED_TAG: 1
+    #             },
+    #             DUMMY_INDEX_FILE
+    #         ).validate().success
+    #     )


### PR DESCRIPTION
This PR makes index ci skip job id check for library and removes string field validation from desired tag.