### PR TITLE
Adds provision to provide exception jobs list while removing stale jobs

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -266,7 +266,8 @@ class BuildConfigManager(object):
         """
         Applies the build job template that creates pipeline to build
         image, and trigger first time build as well.
-        :param project: Name of project, where the template is to be applied
+        :param project: The name of project, where the template is to be
+                        applied
         :param template_location: The location of the template file.
         """
         oc_process = "oc process -f {0} {1}".format(
@@ -457,14 +458,29 @@ class Index(object):
             ccp_openshift_slave_image, notify_cc_emails)
         self.infra_projects = ["seed-job"]
 
-    def find_stale_jobs(self, oc_projects, index_projects):
+    def find_stale_jobs(self,
+                        oc_projects, index_projects,
+                        exception_jobs=["ci-job"]):
         """
         Given oc projects and index projects, figure out stale
-        projects and return
+        projects and return.
+        This method also has provision to take take exception lists.
+        The exception list has names of projects which will be removed
+        from found stale jobs and won't be removed from OpenShift.
+        The desired target for exception list is for: ci-job
+
         """
         # diff existing oc projects from index projects
 
-        return list(set(oc_projects) - set(index_projects))
+        stale_jobs = list(set(oc_projects) - set(index_projects))
+
+        if stale_jobs:
+            # remove the exception list from found stale jobs
+            print ("Removing exception job(s) {} from found stale jobs, "
+                   "mentioned jobs won't be removed OpenShift..".format(
+                       exception_jobs))
+            return list(set(stale_jobs) - set(exception_jobs))
+        return stale_jobs
 
     def run(self, batch_size, polling_interval,
             batch_outstanding_builds_cap):


### PR DESCRIPTION
This is to cater requiremenet of functional CI feature, where
we have added a ci-job. This job is not part of container index
and thus as per principal found stale job when index reader runs.

While finding stale jobs, now we are adding provision to provide
method with exception-jobs list, which will be exempted while finding
stale jobs (which eventually gets removed from OpenShift).
As we don't want ci-job to be removed from OpenShift after index-reader
(or seed-job) is run. The default value for exception_jobs parameter
is ["ci-job"].