### PR TITLE
Continues processing index entries upon errors, updates buildconfig names to lower case

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -126,9 +126,11 @@ class Project(object):
 
     def get_pipeline_name(self):
         """
-        Returns the pipeline name based on the project object values
+        Returns the pipeline name based on appid, jobid and desired_tag
+        and also converts it to lower case
         """
-        return "{}-{}-{}".format(self.app_id, self.job_id, self.desired_tag)
+        return "{}-{}-{}".format(
+            self.app_id, self.job_id, self.desired_tag).lower()
 
 
 class IndexReader(object):
@@ -240,7 +242,7 @@ class BuildConfigManager(object):
         """
         Applies the build job template that creates pipeline to build
         image, and trigger first time build as well.
-        :param project: The name of project, where the template is to be applied
+        :param project: The name of project,where the template is to be applied
         :param template_location: The location of the template file.
         """
         oc_process = "oc process -f {0} {1}".format(

--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -3,7 +3,6 @@ This script parses the container index specified and
 creates the Jenkins pipeline projects from entries of index.
 """
 
-import exceptions
 import re
 import subprocess
 import sys
@@ -12,10 +11,18 @@ import yaml
 from glob import glob
 
 
-class InvalidPipelineName(exceptions.Exception):
+class InvalidPipelineName(Exception):
     """
     Exception to be raised when pipeline name populated doesn't
     confornt to allowed value for openshift template field metadata.name
+    """
+    pass
+
+
+class ErrorAccessingIndexEntryAttributes(Exception):
+    """
+    Exception to be raised when there are errors accessing
+    index entry attributes
     """
     pass
 
@@ -131,9 +138,7 @@ class Project(object):
             self.pre_build_script = self.process_pre_build_script(
                 entry.get("prebuild-script", None))
         except Exception as e:
-            print("Error processing container index entry {}. "
-                  "Moving on".format(entry))
-            print("Error: {}".format(str(e)))
+            raise(ErrorAccessingIndexEntryAttributes(str(e)))
 
     def get_pipeline_name(self):
         """

--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -131,8 +131,9 @@ class Project(object):
             self.pre_build_script = self.process_pre_build_script(
                 entry.get("prebuild-script", None))
         except Exception as e:
-            print ("Error processing container index entry.")
-            raise(e)
+            print("Error processing container index entry {}. "
+                  "Moving on".format(entry))
+            print("Error: {}".format(str(e)))
 
     def get_pipeline_name(self):
         """
@@ -202,9 +203,15 @@ class IndexReader(object):
             app = self.read_yaml(yamlfile)
             for entry in app['Projects']:
                 # create a project object here with all properties
-                project = Project(entry, self.namespace)
-                # append to the list of projects
-                projects.append(project)
+                try:
+                    project = Project(entry, self.namespace)
+                except Exception as e:
+                    print("Error processing index entry {}. Moving on.".format(
+                          entry))
+                    print("Error: {}".format(e))
+                else:
+                    # append to the list of projects
+                    projects.append(project)
 
         return projects
 
@@ -444,7 +451,12 @@ class Index(object):
 
         # oc process and oc apply to all fresh and existing jobs
         for project in index_projects:
-            self.bc_manager.apply_buildconfigs(project)
+            try:
+                self.bc_manager.apply_buildconfigs(project)
+            except Exception as e:
+                print("Error applying/creating build config for {}. "
+                      "Moving on.".format(project.pipeline_name))
+                print("Error: {}".format(str(e)))
 
 
 if __name__ == "__main__":

--- a/tests/test_00_unit/test_00_index_reader/__init__.py
+++ b/tests/test_00_unit/test_00_index_reader/__init__.py
@@ -134,6 +134,16 @@ class TestProject(unittest.TestCase):
             "foo-bar-latest",
             project.pipeline_name)
 
+    def test_get_pipeline_name_3(self):
+        """
+        IndexReader: Tests exception while processing pipeline name
+        """
+        self.entry["app-id"] = "-"
+        self.entry["job-id"] = "-"
+        self.entry["desired-tag"] = "-"
+        with self.assertRaises(index_reader.InvalidPipelineName):
+            index_reader.Project(self.entry, self.namespace)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_00_unit/test_00_index_reader/__init__.py
+++ b/tests/test_00_unit/test_00_index_reader/__init__.py
@@ -114,10 +114,21 @@ class TestProject(unittest.TestCase):
         project = index_reader.Project(self.entry, self.namespace)
         self.assertIsNone(project.pre_build_context)
 
-    def test_get_pipeline_name(self):
+    def test_get_pipeline_name_1(self):
         """
-        Test processing pipeline_name based on given values
+        IndexReader: Tests processing pipeline_name
         """
+        project = index_reader.Project(self.entry, self.namespace)
+        self.assertEqual(
+            "foo-bar-latest",
+            project.pipeline_name)
+
+    def test_get_pipeline_name_2(self):
+        """
+        IndexReader: Tests processing pipeline_name for upper case params
+        """
+        self.entry["app-id"] = "Foo"
+        self.entry["desired-tag"] = "LatesT"
         project = index_reader.Project(self.entry, self.namespace)
         self.assertEqual(
             "foo-bar-latest",

--- a/tests/test_00_unit/test_00_index_reader/__init__.py
+++ b/tests/test_00_unit/test_00_index_reader/__init__.py
@@ -149,7 +149,8 @@ class TestProject(unittest.TestCase):
         IndexReader: Tests exception while loading invalid index entry
         """
         self.entry.pop("target-file")
-        with self.assertRaises(Exception):
+        with self.assertRaises(
+                index_reader.ErrorAccessingIndexEntryAttributes):
             index_reader.Project(self.entry, self.namespace)
 
 

--- a/tests/test_00_unit/test_00_index_reader/__init__.py
+++ b/tests/test_00_unit/test_00_index_reader/__init__.py
@@ -144,6 +144,14 @@ class TestProject(unittest.TestCase):
         with self.assertRaises(index_reader.InvalidPipelineName):
             index_reader.Project(self.entry, self.namespace)
 
+    def test_load_project_entry_failure_case(self):
+        """
+        IndexReader: Tests exception while loading invalid index entry
+        """
+        self.entry.pop("target-file")
+        with self.assertRaises(Exception):
+            index_reader.Project(self.entry, self.namespace)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

1. 
Updated the PR to change the behavior of seed-job as well.
Now the seed-job will continue to process rest of the entries in index if it encountered errors while processing index. It will print the error and move on.


2.
Fix OSIO 1522
Since OpenShift doesn't allow the value of metadata.name to have uppercase chars.
Added a regular expression to validate the pipeline name generated
for using in template's metadata.name field. oc imposes certain guidelines
for same and provides the regular expression in error/help message to be
used for validation in case it found some invalid string.

We are using same regular expression as provided by oc to validate
the pipeline name while processing index and generating build configs
from it.

Added a custom exception, which will be raised if the populated string
is invalid.

Added a unit test as well to test the functionality.

