### PR TITLE
Updates container-capabilities scanner to understand 'null' value

### DIFF
--- a/Dockerfiles/ccp-openshift-scan/Dockerfile
+++ b/Dockerfiles/ccp-openshift-scan/Dockerfile
@@ -4,4 +4,4 @@ ADD scanning /opt/scanning
 
 VOLUME ["/opt/scanning"]
 
-CMD ["/bin/tail", "-f", "/dev/null"]
+CMD ["/bin/sleep", "infinity"]

--- a/Dockerfiles/ccp-openshift-scan/scanning/container-capabilities.py
+++ b/Dockerfiles/ccp-openshift-scan/scanning/container-capabilities.py
@@ -59,7 +59,7 @@ def run_scan(command):
     Runs the container capabilities scan and prints error message
     if provided command is empty
     """
-    if not command:
+    if not command or command == "null":
         print ("\n RUN label is not available in image under test.")
     else:
         check_args(command)


### PR DESCRIPTION
Fix OSIO #1535 : docker inspect will return `null` value if RUN label is absent in image under test.
Container capabilities scanner was taking `null` value as RUN label value. Updated the scanner to understand null value and categorize it as ` RUN label is not available in image under test.`

Also, updated the `CMD` instruction of scan-data container. Now it's `/bin/sleep infinity`.
