### PR TITLE
Use different pod template name for master jobs

### DIFF
--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -31,7 +31,7 @@ objects:
                 containers: [
                   containerTemplate(
                     name: 'jnlp',
-                    image: 'registry.centos.org/dharmit/ccp-openshift-slave',
+                    image: 'registry.centos.org/pipeline-images/ccp-openshift-slave',
                     ttyEnabled: true,
                     alwaysPullImage: true,
                     workingDir: '/tmp',

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -25,8 +25,8 @@ objects:
             ])
             podTemplate(
                 cloud: 'openshift',
-                name: 'ccp-pipeline',
-                label: 'ccp-pipeline',
+                name: 'ccp-pipeline-seed',
+                label: 'ccp-pipeline-seed',
                 serviceAccount: 'jenkins',
                 containers: [
                   containerTemplate(
@@ -41,7 +41,7 @@ objects:
                 ],
             )
             {
-                node ('ccp-pipeline'){
+                node ('ccp-pipeline-seed'){
                     stage('Checkout Sources') {
                         dir("${CONTAINER_INDEX_DIR}") {
                             git url: '${CONTAINER_INDEX_REPO}', branch: '${CONTAINER_INDEX_BRANCH}'

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -28,8 +28,8 @@ objects:
             ])
             podTemplate(
                 cloud: 'openshift',
-                name: 'ccp-pipeline',
-                label: 'ccp-pipeline',
+                name: 'ccp-pipeline-master',
+                label: 'ccp-pipeline-master',
                 serviceAccount: 'jenkins',
                 containers: [
                   containerTemplate(
@@ -50,7 +50,7 @@ objects:
                 ]
             )
             {
-                node('ccp-pipeline') {
+                node('ccp-pipeline-master') {
                     def image_name = "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def daemonset_name = "scan-data_scan-data"

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -19,8 +19,8 @@ objects:
             ])
             podTemplate(
                 cloud: 'openshift',
-                name: 'ccp-pipeline',
-                label: 'ccp-pipeline',
+                name: 'ccp-pipeline-weekly',
+                label: 'ccp-pipeline-weekly',
                 serviceAccount: 'jenkins',
                 containers: [
                   containerTemplate(
@@ -41,7 +41,7 @@ objects:
                 ]
             )
             {
-                node('ccp-pipeline') {
+                node('ccp-pipeline-weekly') {
                     def image_name = "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def image_tags = "http://${REGISTRY_URL}/v2/${APP_ID}/${JOB_ID}/tags/list"


### PR DESCRIPTION
This PR fixes the docker daemon absent error we have been observing when seed-job is still parsing the container index and few of the parsed jobs already start getting built by OpenShift Jenkins.

Added later:

This PR now makes sure that
- weekly-scan jobs have their own pod templates
- container image being used to spin up jenkins slave pod is based on upstream.
- unique pod template names for every kind of job, i.e., seed-job, master-jobs, weekly-scans