### PR TITLE
Added job config for unit tests and functional tests with service job

### DIFF
--- a/ci/jjb_service_job.yml
+++ b/ci/jjb_service_job.yml
@@ -1,5 +1,5 @@
 - job:
-    name: centos-container-pipeline-service-job-openshift
+    name: 'centos-container-pipeline-service-job-openshift'
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     node: container

--- a/ci/jjb_service_job.yml
+++ b/ci/jjb_service_job.yml
@@ -1,0 +1,22 @@
+- job:
+    name: centos-container-pipeline-service-job-openshift
+    description: |
+        Managed by Jenkins Job Builder, do not edit manually!
+    node: container
+    properties:
+        - github:
+            url: https://github.com/CentOS/container-pipeline-service
+    triggers:
+        - github
+
+    wrappers:
+        - ansicolor
+    scm:
+        - git:
+            url: https://github.com/CentOS/container-pipeline-service.git
+            skip-tag: True
+            branches:
+                - openshift
+    builders:
+        - shell: |
+            jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini update ci/job.yml

--- a/ci/jjb_service_job.yml
+++ b/ci/jjb_service_job.yml
@@ -1,6 +1,10 @@
 - job:
     name: 'centos-container-pipeline-service-job-openshift'
     description: |
+        This job is a service job for managing all the CI jobs from container-pipeline-service https://github.com/centos/container-pipeline-service
+
+        This job is currently tracking openshift branch of the repo and gets triggered when commits are pushed to the openshift branch of the repo
+
         Managed by Jenkins Job Builder, do not edit manually!
     node: container
     properties:

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -1,0 +1,161 @@
+- job:
+    name: centos-container-pipeline-service-container-index
+    description: |
+        Managed by Jenkins Job Builder, do not edit manually!
+    node: container
+    properties:
+        - github:
+            url: https://github.com/CentOS/container-index
+    triggers:
+        - github-pull-request:
+            admin-list:
+              - kbsingh
+              - bamachrn
+              - mohammedzee1000
+              - dharmit
+              - navidshaikh
+            white-list:
+              - kbsingh
+              - bamachrn
+              - mohammedzee1000
+              - dharmit
+              - navidshaikh
+            cron: '* * * * *'
+            github-hooks: false
+            permit-all: true
+
+    wrappers:
+        - ansicolor
+    scm:
+        - git:
+            url: https://github.com/CentOS/container-index.git
+            skip-tag: True
+            git-tool: ci-git
+            branches: master
+            refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+            branches:
+                - "${ghprbactualcommit}"
+    builders:
+        - shell: |
+            git rebase origin/${ghprbTargetBranch}
+            curl https://raw.githubusercontent.com/CentOS/container-pipeline-service/master/ci/cccp_ci_container_index.sh > cccp_ci_container_index.sh
+            sh ./cccp_ci_container_index.sh
+
+- job:
+    name: 'centos-container-pipeline-service-ci-pr-openshift'
+    description: |
+        Managed by Jenkins Job Builder, do not edit manually!
+    node: container
+    ci_project: container
+    properties:
+        - github:
+            url: https://github.com/CentOS/container-pipeline-service/
+    triggers:
+        - github-pull-request:
+            admin-list:
+                - kbsingh
+                - bamachrn
+                - dharmit
+                - navidshaikh
+                - mohammedzee1000
+                - cdrage
+            white-list:
+                - kbsingh
+                - bamachrn
+                - dharmit
+                - navidshaikh
+                - mohammedzee1000
+                - cdrage
+            trigger-phrase: '#dotests'
+            only-trigger-phrase: true
+            github-hooks: true
+            permit-all: false
+            auto-close-on-fail: false
+            status-context: "centos-ci functional tests"
+            started-status: "centos-ci functional tests started"
+            success-status: "centos-ci functional tests succeeded"
+            failure-status: "centos-ci functional tests failed"
+            error-status: "centos-ci functional tests errored"
+    wrappers:
+        - ansicolor
+    scm:
+        - git:
+            url: https://github.com/CentOS/container-pipeline-service.git
+            skip-tag: True
+            git-tool: ci-git
+            branches: master
+            refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+            branches:
+                - "${sha1}"
+    builders:
+        - shell: |
+            echo ${sha1}
+            echo ${GIT_URL}
+            echo ${GIT_BRANCH}
+            if [ ${ghprbTargetBranch} == "openshift" ]
+            then
+              git rebase origin/${ghprbTargetBranch}
+              cd ci
+              sh trigger_ci.sh ${GIT_URL} ${GIT_BRANCH} ${sha1}
+            else
+              echo "It is not on openshit branch"
+            fi
+
+- job:
+    name: 'centos-container-pipeline-service-ci-pr-unittests'
+    description: |
+        Managed by Jenkins Job Builder, do not edit manually!
+    node: container
+    ci_project: container
+    properties:
+        - github:
+            url: https://github.com/CentOS/container-pipeline-service/
+    triggers:
+        - github-pull-request:
+            admin-list:
+                - kbsingh
+                - bamachrn
+                - dharmit
+                - navidshaikh
+                - mohammedzee1000
+                - cdrage
+            white-list:
+                - kbsingh
+                - bamachrn
+                - dharmit
+                - navidshaikh
+                - mohammedzee1000
+                - cdrage
+            trigger-phrase: '#dotests-unittests'
+            only-trigger-phrase: true
+            github-hooks: true
+            permit-all: false
+            auto-close-on-fail: false
+            status-context: "centos-ci unit tests"
+            started-status: "centos-ci unit tests started"
+            success-status: "centos-ci unit tests succeeded"
+            failure-status: "centos-ci unit tests failed"
+            error-status: "centos-ci unit tests errored"
+    wrappers:
+        - ansicolor
+    scm:
+        - git:
+            url: https://github.com/CentOS/container-pipeline-service.git
+            skip-tag: True
+            git-tool: ci-git
+            branches: master
+            refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+            branches:
+                - "${sha1}"
+    builders:
+        - shell: |
+            echo ${sha1}
+            echo ${GIT_URL}
+            echo ${GIT_BRANCH}
+            if [ ${ghprbTargetBranch} == "openshift" ]
+            then
+              git rebase origin/${ghprbTargetBranch}
+              bash ci/ccp_ci_unittests.sh
+            else
+              echo "It is not on openshit branch"
+            fi

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -1,6 +1,14 @@
 - job:
-    name: 'centos-container-pipeline-service-container-index'
+    name: 'centos-container-index-ci'
     description: |
+        This job is for running the CI jobs for the PRs raised to
+        https://github.com/centos/container-index.git
+        It runs the CI tests from the pipeline service repository
+        (https://github.com/centos/container-pipeline-service)
+
+        This job gets triggered when there is a PR raised to container-index
+        or \#dotests on the raised PRs
+
         Managed by Jenkins Job Builder, do not edit manually!
     node: container
     properties:
@@ -27,10 +35,10 @@
             permit-all: false
             auto-close-on-fail: false
             status-context: "centos-ci container-index ci tests"
-            started-status: "centos-ci container-index ci  tests started"
-            success-status: "centos-ci container-index ci  tests succeeded"
-            failure-status: "centos-ci container-index ci  tests failed"
-            error-status: "centos-ci container-index ci  tests errored"
+            started-status: "centos-ci container-index ci tests started"
+            success-status: "centos-ci container-index ci tests succeeded"
+            failure-status: "centos-ci container-index ci tests failed"
+            error-status: "centos-ci container-index ci tests errored"
     wrappers:
         - ansicolor
     scm:
@@ -51,6 +59,12 @@
 - job:
     name: 'centos-container-pipeline-service-ci-pr-functional'
     description: |
+        This job is for running the functional CI jobs for the PRs raised to
+        https://github.com/centos/container-pipeline-service
+
+        This job gets triggered when there is a PR raised to container-pipeline-service
+        or \#dotests on the raised PRs
+
         Managed by Jenkins Job Builder, do not edit manually!
     node: container
     ci_project: container
@@ -105,12 +119,18 @@
               cd ci
               sh trigger_ci.sh ${GIT_URL} ${GIT_BRANCH} ${sha1}
             else
-              echo "PRs target branch is not openshift"
+              echo "PR's target branch is not openshift"
             fi
 
 - job:
     name: 'centos-container-pipeline-service-ci-pr-unittests'
     description: |
+        This job is for running the unit tests CI jobs for the PRs raised to
+        https://github.com/centos/container-pipeline-service
+
+        This job gets triggered when there is a PR raised to container-pipeline-service
+        or \#dotests-unittests on the raised PRs
+
         Managed by Jenkins Job Builder, do not edit manually!
     node: container
     ci_project: container
@@ -164,5 +184,5 @@
               git rebase origin/${ghprbTargetBranch}
               bash ci/ccp_ci_unittests.sh
             else
-              echo "PRs target branch is not openshift"
+              echo "PR's target branch is not openshift"
             fi

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -1,5 +1,5 @@
 - job:
-    name: centos-container-pipeline-service-container-index
+    name: 'centos-container-pipeline-service-container-index'
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     node: container
@@ -21,9 +21,16 @@
               - dharmit
               - navidshaikh
             cron: '* * * * *'
-            github-hooks: false
-            permit-all: true
-
+            trigger-phrase: '#dotests'
+            only-trigger-phrase: false
+            github-hooks: true
+            permit-all: false
+            auto-close-on-fail: false
+            status-context: "centos-ci container-index ci tests"
+            started-status: "centos-ci container-index ci  tests started"
+            success-status: "centos-ci container-index ci  tests succeeded"
+            failure-status: "centos-ci container-index ci  tests failed"
+            error-status: "centos-ci container-index ci  tests errored"
     wrappers:
         - ansicolor
     scm:
@@ -42,7 +49,7 @@
             sh ./cccp_ci_container_index.sh
 
 - job:
-    name: 'centos-container-pipeline-service-ci-pr-openshift'
+    name: 'centos-container-pipeline-service-ci-pr-functional'
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     node: container
@@ -98,7 +105,7 @@
               cd ci
               sh trigger_ci.sh ${GIT_URL} ${GIT_BRANCH} ${sha1}
             else
-              echo "It is not on openshit branch"
+              echo "PRs target branch is not openshift"
             fi
 
 - job:
@@ -157,5 +164,5 @@
               git rebase origin/${ghprbTargetBranch}
               bash ci/ccp_ci_unittests.sh
             else
-              echo "It is not on openshit branch"
+              echo "PRs target branch is not openshift"
             fi

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -67,7 +67,7 @@
                 - mohammedzee1000
                 - cdrage
             trigger-phrase: '#dotests'
-            only-trigger-phrase: true
+            only-trigger-phrase: false
             github-hooks: true
             permit-all: false
             auto-close-on-fail: false
@@ -127,7 +127,7 @@
                 - mohammedzee1000
                 - cdrage
             trigger-phrase: '#dotests-unittests'
-            only-trigger-phrase: true
+            only-trigger-phrase: false
             github-hooks: true
             permit-all: false
             auto-close-on-fail: false


### PR DESCRIPTION
This PR contains job configs for 
* service job: This configures and updates all the CI job for container-pipeline-service
* container-index-ci: This job runs from container-pipeline-master and checks sanity for container-index
* container-pipeline-service-ci-pr-openshift: This runs functional tests for service from openshift branch of the repo.
   *  This runs in each PR raised to the openshift branch of container-pipeline-service repo
   *  #dotests manually triggers it 
* container-pipeline-service-ci-pr-unittests: This runs unit tests for service from the openshift branch of the repo.
   *  This runs in each PR raised to the openshift branch of container-pipeline-service repo
   *  #dotests-unittests manually triggers it

All the test jobs updates their status with a different status-context which shows up in github as multiple checks