### PR TITLE
Fixes bugs in scanners

### DIFF
--- a/Dockerfiles/ccp-openshift-scan/scanning/container-capabilities.py
+++ b/Dockerfiles/ccp-openshift-scan/scanning/container-capabilities.py
@@ -46,7 +46,7 @@ def check_args(cmd):
             if not found_sec_arg:
                 print("\nThis container uses privileged "
                       "security switches:")
-            print("\nINFO: {}\n\t{}".format(sec_arg, security_args[sec_arg]))
+            print("\nINFO: {0}\n\t{1}".format(sec_arg, security_args[sec_arg]))
             found_sec_arg = True
     if found_sec_arg:
         print("\nFor more information on these switches and their "
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 2:
         example = ('python container-capabilities.py'
                    ' "docker run --privileged $IMAGE /bin/true"')
-        print ("Please provide one argument as\n{}".format(example))
+        print ("Please provide one argument as\n{0}".format(example))
         sys.exit(1)
 
     try:
@@ -77,5 +77,5 @@ if __name__ == "__main__":
         run_scan(cli_arg)
     except Exception as e:
         print ("Error occurred in Container Capabilities scanner execution.")
-        print ("Error: %s".format(e))
+        print ("Error: {0}".format(e))
         sys.exit(1)

--- a/Dockerfiles/ccp-openshift-scan/scanning/misc_package_updates.py
+++ b/Dockerfiles/ccp-openshift-scan/scanning/misc_package_updates.py
@@ -32,7 +32,7 @@ def find_pip_updates(executable="/usr/bin/pip"):
 
     if err:
         if binary_does_not_exist(err):
-            return "{} is not installed".format(executable)
+            return "{0} is not installed".format(executable)
         else:
             return "Failed to find the pip updates."
     else:
@@ -56,7 +56,7 @@ def find_npm_updates(executable="/usr/bin/npm"):
 
     if err:
         if binary_does_not_exist(err):
-            return "{} is not installed".format(executable)
+            return "{0} is not installed".format(executable)
         else:
             return "Failed to find the npm updates."
     else:
@@ -80,7 +80,7 @@ def find_gem_updates(executable="/usr/bin/gem"):
 
     if err:
         if binary_does_not_exist(err):
-            return "{} is not installed".format(executable)
+            return "{0} is not installed".format(executable)
         else:
             return "Failed to find the gem updates."
     else:
@@ -94,7 +94,7 @@ def print_updates(binary):
     """
     Prints the updates found using given binary
     """
-    print ("\n{} updates scan:".format(binary))
+    print ("\n{0} updates scan:".format(binary))
 
     if binary == "npm":
         result = find_npm_updates()
@@ -122,14 +122,14 @@ if __name__ == "__main__":
 
     if len(sys.argv) < 2:
         example = "python misc_package_updates.py npm"
-        print ("Please provide at least one argument as\n{}".format(example))
-        print ("Valid arguments: {}".format(valid_args))
+        print ("Please provide at least one argument as\n{0}".format(example))
+        print ("Valid arguments: {0}".format(valid_args))
         sys.exit(1)
 
     cli_arg = sys.argv[1].strip()
 
     if cli_arg not in valid_args:
-        print ("Please provide valid args among {}".format(valid_args))
+        print ("Please provide valid args among {0}".format(valid_args))
         sys.exit(1)
 
     try:
@@ -141,5 +141,5 @@ if __name__ == "__main__":
             print_updates(cli_arg)
     except Exception as e:
         print ("Error occurred in Misc Package Updates scanner execution.")
-        print ("Error: %s".format(e))
+        print ("Error: {0}".format(e))
         sys.exit(1)

--- a/Dockerfiles/ccp-openshift-scan/scanning/rpmverify.py
+++ b/Dockerfiles/ccp-openshift-scan/scanning/rpmverify.py
@@ -7,6 +7,7 @@
 
 
 import re
+import sys
 
 import scan_lib
 
@@ -86,7 +87,7 @@ class RPMVerify(object):
         """
         cmd = ["/bin/rpm", "-qf", filepath]
         out, _ = scan_lib.run_cmd_out_err(cmd)
-        return out.split("\n")[0]
+        return out.split("\n")[0].strip()
 
     def filter_expected_dirs_modifications(self, filepath):
         """
@@ -144,6 +145,9 @@ class RPMVerify(object):
 
             rpm = self.source_rpm_of_file(filepath)
 
+            if not rpm:
+                continue
+
             result.append({
                 "issue": match.groups()[0],
                 "config": match.groups()[1] == 'c',
@@ -170,7 +174,7 @@ class RPMVerify(object):
                    "binaries are intact in image.")
             return
         for line in result:
-            print ("\nFile: {}".format(line.get("filename")))
+            print ("\nFile: {0}".format(line.get("filename")))
 
             # find out what all issues with file are
             file_issues_encoded = line["issue"].strip().replace(".", "")
@@ -184,7 +188,7 @@ class RPMVerify(object):
 
             print ("Issue with file:")
             for issue in file_issues:
-                print ("\t- {}".format(issue))
+                print ("\t- {0}".format(issue))
 
             print ("RPM info:")
             for key, value in line.get("rpm", {}).iteritems():
@@ -198,5 +202,5 @@ if __name__ == "__main__":
         rpmverify.print_result(result)
     except Exception as e:
         print ("Error occurred in RPM Verify scanner execution.")
-        print ("Error: %s".format(e))
+        print ("Error: {0}".format(e))
         sys.exit(1)

--- a/Dockerfiles/ccp-openshift-scan/scanning/yumupdates.py
+++ b/Dockerfiles/ccp-openshift-scan/scanning/yumupdates.py
@@ -1,44 +1,117 @@
-# scan script for yum list update scannr
+# scan script for yum list update scanner
 
-import scan_lib
+import sys
+import yum
 
 
-def yum_updates():
+class SysStdoutSuppressor(object):
     """
-    Finds yum updates
+    Class which can be used to mute output printed
+    on sys.stdout.
+    It just mutes the sys.stdout and takes care of raising
+    the exception if encountered in calling method.
     """
-    command = ["yum", "-q", "check-update"]
-    out, err = scan_lib.run_cmd_out_err(command)
-    return out, err
+
+    def __enter__(self):
+        self.stdout = sys.stdout
+        sys.stdout = self
+
+    def __exit__(self, type, value, traceback):
+        # revert back sys.stdout to original form before exiting
+        sys.stdout = self.stdout
+        if type is not None:
+            raise(value)
+
+    def write(self, x):
+        """
+        Overriding sys.stdout.write, this method won't print
+        on stdout
+        """
+        pass
 
 
-def find_updates():
+class YumUpdates(object):
     """
-    process yum updates
+    Class with related methods to find the yum updates
+    available using python yum API client
     """
-    out, err = yum_updates()
-    if err:
-        print ("Error:")
-        print ("Error retrieving yum updates.\n{}".format(err))
-        return
-    out = out.strip()
 
-    if not out:
-        print ("No yum updates required.")
-        return
+    def __init__(self):
+        """
+        Instantiate
+        :arg needed_fields: Properties of RPM object  while processing
+        """
+        self.yum_obj = yum.YumBase()
+        self.needed_fields = ["name", "vra", "repo"]
 
-    out = out.split("\n")
-    print ("RPM\t\t\tNew-Version")
-    for update in out:
-        # split each line separated by tabs
-        update = update.split()
-        print ("{}\t\t{}".format(update[0], update[1]))
+    def find_updates(self):
+        """
+        Find yum updates and returns the needed_fields attributes of RPM
+        as dictionary for available RPM updates. Returns empty dictionary
+        if no updates are required.
+
+        :return: List of dictionaries of needed_fields as keys and value
+                 as its output
+        :rtype: List
+        """
+        # narrow the package filter to updates
+        rpms = self.yum_obj.doPackageLists(pkgnarrow="updates")
+        updates = []
+        for each in rpms:
+            # check if generator even returned an object
+            # case when no updates are available
+            if not each:
+                continue
+
+            # this is to find out the installed version of
+            # package which is listed in update
+            installed_rpm_gen = self.yum_obj.doPackageLists(
+                pkgnarrow="installed",
+                patterns=[each.name])
+
+            # since it returns a generator, we need to iterate
+            installed_rpm = ""
+            for i in installed_rpm_gen:
+                installed_rpm = i
+                break
+
+            updates.append(
+                {
+                    "name": each.name,
+                    "installed": installed_rpm,
+                    "update": each.ui_nevra,
+                    "repo": each.repo
+                }
+            )
+        return updates
+
+    def print_updates(self, updates):
+        """
+        Print the updates on stdout
+        :arg updates: Updates provided as list of dictionaries,
+                      the output received from find_updates() method
+        :type updates: List
+        """
+        if not updates:
+            print("No RPM updates available as per configured yum repos.")
+            return
+
+        # print the number of updates available
+        print ("About {0} RPM updates are identified.".format(len(updates)))
+
+        # now print individual RPM update info
+        for each in updates:
+            # separate updates with extra new lines
+            print("\n")
+            print("Name:        {0}".format(each["name"]))
+            print("Installed:   {0}".format(each["installed"]))
+            print("Update :     {0}".format(each["update"]))
+            print("Yum Repo:    {0}".format(each["repo"]))
 
 
 if __name__ == "__main__":
-    try:
-        find_updates()
-    except Exception as e:
-        print ("Error occurred in RPM Updates scanner execution.")
-        print ("Error: %s".format(e))
-        sys.exit(1)
+    y = YumUpdates()
+    # prevent repo update downloads stdout
+    with SysStdoutSuppressor():
+        updates = y.find_updates()
+    y.print_updates(updates)

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -101,20 +101,20 @@ objects:
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
                                   sh "cat yum-check-update"
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
                                   sh "cat rpm-verify"
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
                                   sh "cat misc-updates"
                                 },
                                 "Container capabilities": {
                                   def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
                                   sh "cat capabilities"
                                 }
                             )


### PR DESCRIPTION
This changeset fixes bugs in scanners.

 1. Uses yum python API client library to list yum updates
    
      Stops using system commands and parsing stdout, now uses
      yum python API client library to list and print the updates
      in cleaner way.
    
     Uses a Suppressor for not printing the yum repo updates stdout
     before printing results.
    
     Adds ability to list installed version of package, for which
     updates are available.
     Adds ability to list the source yum repo.

 2. Adds error checking in rpmverify scanner
    
    Adds missing sys import
    Adds formating indexes to be compatible for python version in
    centos6 images.

 3. Fixes string formatting in misc and capabilities scanner
    
      Fixes string formatting
      Uses explicit indexes in string formatting for python version
      in centos6 image

4.  Uses /usr/bin/python as entrypoint to stay compatible with centos6 images
    
      Since python is installed at /usr/bin/python in CentOS6 image,
      and earlier we were using /bin/python , which is unavailable in
      CentOS6 image.
      CentOS7 image has needed symlinks to stay compatible with either
      /usr/bin/python or /usr/bin/python.
