### PR TITLE
Sends weekly scan notification email with additional information

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -235,6 +235,7 @@ class BuildConfigManager(object):
 -p CCP_OPENSHIFT_SLAVE_IMAGE={ccp_openshift_slave_image}"""
 
         self.weekly_scan_template_params = """\
+-p NAMESPACE={namespace} \
 -p PIPELINE_NAME=wscan-{pipeline_name} \
 -p REGISTRY_URL={registry_url} \
 -p NOTIFY_EMAIL={notify_email} \
@@ -338,6 +339,7 @@ class BuildConfigManager(object):
 
         # format the command with project params
         command = command.format(
+            namespace=self.namespace,
             git_url=project.git_url,
             git_branch=project.git_branch,
             desired_tag=project.desired_tag,

--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -238,6 +238,7 @@ class BuildConfigManager(object):
 -p PIPELINE_NAME=wscan-{pipeline_name} \
 -p REGISTRY_URL={registry_url} \
 -p NOTIFY_EMAIL={notify_email} \
+-p NOTIFY_CC_EMAILS={notify_cc_emails} \
 -p APP_ID={app_id} \
 -p JOB_ID={job_id} \
 -p DESIRED_TAG={desired_tag} \
@@ -347,7 +348,8 @@ class BuildConfigManager(object):
             registry_url=self.registry_url,
             from_address=self.from_address,
             smtp_server=self.smtp_server,
-            ccp_openshift_slave_image=self.ccp_openshift_slave_image
+            ccp_openshift_slave_image=self.ccp_openshift_slave_image,
+            notify_cc_emails=self.notify_cc_emails
         )
         # process and apply buildconfig
         output = run_cmd(command, shell=True)

--- a/ccp/notifications/base.py
+++ b/ccp/notifications/base.py
@@ -18,6 +18,12 @@ class BaseNotify(object):
             "[{registry}] SUCCESS: Container build {image_name}"
         self.build_failure_subj = \
             "[{registry}] FAILED: Container build {image_name}"
+
+        self.weekly_success_subj = \
+            "[{registry}] SUCCESS: Weekly scan for {image_name}"
+        self.weekly_failure_subj = \
+            "[{registry}] FAILED: Weekly scan for {image_name}"
+
         # <30 is adding space formatting for aligning the key values
         self.build_success_body = """\
 {0:<30}{1}
@@ -28,6 +34,13 @@ class BaseNotify(object):
 {0:<30}{1}
 {2:<30}{3}"""
 
+        self.weekly_body = """\
+{0:<30}{1}
+{2:<30}{3}"""
+
+        self.weekly_image_absent_body = "{0:<30}{1}"
+
+        # email footer to be added in all types of notifications
         self.email_footer = """\
 --
 Do you have a query?

--- a/ccp/notifications/notify.py
+++ b/ccp/notifications/notify.py
@@ -13,7 +13,7 @@ from ccp.lib.email import SendEmail
 
 class BuildNotify(BaseNotify):
     """
-    Notify class has related methods to notify
+    BuildNotify class has related methods to notify
     user about build status and details
     """
 

--- a/ccp/notifications/weeklynotify.py
+++ b/ccp/notifications/weeklynotify.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python2
+
+# This python module takes care of getting required details
+# and sending email to user about weekly scan
+
+
+import sys
+
+from ccp.notifications.base import BaseNotify
+from ccp.lib.openshift import BuildInfo
+from ccp.lib.email import SendEmail
+
+
+class WeeklyScanNotify(BaseNotify):
+    """
+    WeeklyScanNotify class has related methods to notify
+    user about weekly scan status and info
+    """
+
+    def __init__(self):
+        # instantiate the base class
+        super(WeeklyScanNotify, self).__init__()
+
+        # create build info object to retrieve build info to send email
+        self.buildinfo_obj = BuildInfo(
+            service_account="sa/jenkins",
+            required_fields=[
+                "NOTIFY_EMAIL",
+                "NOTIFY_CC_EMAILS",
+                "REGISTRY_URL",
+                "FROM_ADDRESS",
+                "SMTP_SERVER"])
+        # create send email utility object for sending emails
+        self.sendemail_obj = SendEmail()
+
+    def body_of_email(self, status, repository):
+        """
+        Generate the body of email for weekly scan notification email
+
+        :param status: Status of build - True=Success False=Failure
+        :type status bool
+        :param repository: Repository name with https:// prefix
+        :type repository str
+        :return: Body of email in text
+        """
+
+        if status:
+            body = self.weekly_body.format(
+                "Scan status:", "Success",
+                "Repository:", repository)
+        else:
+            body = self.weekly_body.format(
+                "Scan status:", "Failure",
+                "Repository:", repository)
+
+        return body + "\n\n" + self.email_footer
+
+    def image_absent_email_body(self):
+        """
+        Generates the body of email for weekly scan notification when
+        image is absent in the registry and scan has failed.
+
+        :return: Body of email in text
+        """
+        body = self.weekly_image_absent_body.format(
+            "Scan status:",
+            "Image is absent in the registry, scan is aborted.")
+        return body + "\n\n" + self.email_footer
+
+    def notify(self,
+               status, namespace, jenkins_url,
+               image_name, build_number, pipeline_name):
+        """
+        Notify the user by sending email about weekly scan info
+
+        :param status: Status of weekly scan performed
+                       ["success", "failed", "image_absent"]
+        :type status str
+        :param namespace: Namespace of the build
+        :type namespace str
+        :param jenkins_url: Jenkins URL to fetch the build info
+        :type jenkins_url str
+        :param image_name: Name of the scanned image
+        :type image_name str
+        :param build_number: Build number of weekly scan at Jenkins
+        :type build_number str / int
+        :param pipeline_name: Pipeline name
+        :type pipeline_name str
+        """
+
+        build_info = self.buildinfo_obj.get_build_info(
+            namespace, jenkins_url,
+            pipeline_name, build_number)
+
+        # possible values are ["success", "failed", "image_absent"]
+        if status == "image_absent":
+            body = self.image_absent_email_body()
+        else:
+            # convert status to boolean
+            status = True if status == "success" else False
+
+            # get the repository name (without tag)
+            repository = "https://" + build_info.get("REGISTRY_URL") + \
+                "/" + image_name.split(":")[0]
+            # body should have repository name (without tag)
+            body = self.body_of_email(status, repository)
+
+        # registry name without ports
+        registry = build_info.get("REGISTRY_URL").strip().split(":")[0]
+
+        # format the subject of email
+        if status and status != "image_absent":
+            subject = self.weekly_success_subj.format(
+                registry=registry, image_name=image_name)
+        else:
+            subject = self.weekly_failure_subj.format(
+                registry=registry, image_name=image_name)
+
+        # NOTIFY_CC_EMAILS list
+        cc_emails = build_info.get("NOTIFY_CC_EMAILS", False)
+        if cc_emails and cc_emails != "null":
+            # convert comma separated emails to list of emails
+            cc_emails = [e.strip() for e in cc_emails.strip(
+                ).split(",") if e]
+        else:
+            cc_emails = []
+
+        print ("Sending weekly scan email to {}".format(
+            build_info.get("NOTIFY_EMAIL")))
+
+        status, msg = self.sendemail_obj.email(
+            build_info.get("SMTP_SERVER"),
+            subject, body,
+            build_info.get("FROM_ADDRESS"),
+            [build_info.get("NOTIFY_EMAIL")],
+            cc_emails)
+
+        if status:
+            print(msg)
+        else:
+            print("Failed to send email!")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    notify_object = WeeklyScanNotify()
+    status = sys.argv[1].strip()
+    namespace = sys.argv[2].strip()
+    jenkins_url = sys.argv[3].strip()
+    image_name = sys.argv[4].strip()
+    build_number = sys.argv[5].strip()
+    pipeline_name = sys.argv[6].strip()
+
+    notify_object.notify(
+        status, namespace, jenkins_url,
+        image_name, build_number,
+        pipeline_name)

--- a/tests/test_00_unit/test_01_notifications/test_weeklynotify.py
+++ b/tests/test_00_unit/test_01_notifications/test_weeklynotify.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python2
+# -*- coding: utf_8 -*-
+
+import unittest
+
+from ccp.notifications import weeklynotify
+
+
+class TestWeeklyNotify(unittest.TestCase):
+    """
+    Tests WeeklyNotify class, responsible for notifying
+    users about weekly scan status.
+    """
+
+    def setUp(self):
+        self.notify_obj = weeklynotify.WeeklyScanNotify()
+
+    def test_body_of_email(self):
+        """
+        Notifications.Weekly: Tests processing body of email
+        """
+
+        status = True
+        repository = "https://registry.centos.org/foo/bar"
+        expected_value = """\
+Scan status:                  Success
+Repository:                   https://registry.centos.org/foo/bar
+
+--
+Do you have a query?
+Talk to CentOS Container Pipeline team on #centos-devel at freenode
+https://wiki.centos.org/ContainerPipeline
+"""
+        self.assertEqual(
+            self.notify_obj.body_of_email(
+                status,
+                repository),
+            expected_value)
+
+    def test_image_absent_email_body(self):
+        """
+        Notifications.Weekly: Tests email body for image absent case
+        """
+        expected_value = """\
+Scan status:                  Image is absent in the registry, scan is aborted.
+
+--
+Do you have a query?
+Talk to CentOS Container Pipeline team on #centos-devel at freenode
+https://wiki.centos.org/ContainerPipeline
+"""
+        self.assertEqual(
+            self.notify_obj.image_absent_email_body(),
+            expected_value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -83,21 +83,26 @@ objects:
                         }
                     }
                     finally {
-                        if (image_in_registry==true) {
+                        stage("Notify user") {
+                          sh "mkfifo /var/spool/postfix/public/pickup && postfix start"
+                          if (image_in_registry==true) {
                             if (success==true) {
-                                sh "echo -e 'Weekly scan for ${image_name_with_registry} was successful' | mail -r ${FROM_ADDRESS} -S smtp=${SMTP_SERVER} -s 'SUCCESS: Weekly scan for ${image_name_with_registry} is complete' ${NOTIFY_EMAIL} "
+                              sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py success cccp `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                             } else {
-                                sh "echo -e 'Weekly scan for ${image_name_with_registry} was unsuccessful' | mail -r ${FROM_ADDRESS} -S smtp=${SMTP_SERVER} -s 'FAILED: Weekly scan ${image_name_with_registry} has failed' ${NOTIFY_EMAIL} "
+                              sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py failure cccp `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                             }
-                        } else {
-                          sh "echo -e 'Weekly scan for ${image_name} was unsuccessful as image not in registry' | mail -r ${FROM_ADDRESS} -S smtp=${SMTP_SERVER} -s 'FAILED: Weekly scan ${image_name} has failed, as image not in registry' ${NOTIFY_EMAIL} "
+                          } else {
+                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py image_absent cccp `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                         }
+                      }
                     }
                 }
             }
           env:
           - name: NOTIFY_EMAIL
             value: ${NOTIFY_EMAIL}
+          - name: NOTIFY_CC_EMAILS
+            value: ${NOTIFY_CC_EMAILS}
           - name: REGISTRY_URL
             value: ${REGISTRY_URL}
           - name: IMAGE_NAME
@@ -110,11 +115,22 @@ objects:
             value: ${JOB_ID}
           - name: DESIRED_TAG
             value: ${DESIRED_TAG}
+          - name: PIPELINE_REPO_DIR
+            value: ${PIPELINE_REPO_DIR}
+          - name: FROM_ADDRESS
+            value: ${FROM_ADDRESS}
+          - name: SMTP_SERVER
+            value: ${SMTP_SERVER}
 parameters:
 - description: Email to send notification to
   displayName: Notification email
   name: NOTIFY_EMAIL
   required: true
+- description: Comma separated email addresses to add in Cc
+  displayName: Notification Cc emails
+  name: NOTIFY_CC_EMAILS
+  required: false
+  value: "null"
 - description: Name of the Pipeline as we want to show up on OpenShift console
   displayName: Pipeline Name
   name: PIPELINE_NAME
@@ -142,6 +158,11 @@ parameters:
   displayName: SMTP server address
   name: SMTP_SERVER
   required: true
+- description: Directory where Pipeline service code is present in slave container
+  displayName: Pipeline service code repo directory
+  name: PIPELINE_REPO_DIR
+  required: true
+  value: /opt/ccp-openshift
 - description: ccp-openshift-slave container image name (with registry name)
   displayName: ccp-openshift-slave container image
   name: CCP_OPENSHIFT_SLAVE_IMAGE

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -87,18 +87,20 @@ objects:
                           sh "mkfifo /var/spool/postfix/public/pickup && postfix start"
                           if (image_in_registry==true) {
                             if (success==true) {
-                              sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py success cccp `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
+                              sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py success ${NAMESPACE} `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                             } else {
-                              sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py failure cccp `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
+                              sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py failure ${NAMESPACE} `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                             }
                           } else {
-                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py image_absent cccp `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
+                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py image_absent ${NAMESPACE} `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                         }
                       }
                     }
                 }
             }
           env:
+          - name: NAMESPACE
+            value: ${NAMESPACE}
           - name: NOTIFY_EMAIL
             value: ${NOTIFY_EMAIL}
           - name: NOTIFY_CC_EMAILS
@@ -122,6 +124,10 @@ objects:
           - name: SMTP_SERVER
             value: ${SMTP_SERVER}
 parameters:
+- description: Namespace to which the resulting Jenkins Pipelines should belong
+  displayName: OpenShift namespace
+  name: NAMESPACE
+  required: true
 - description: Email to send notification to
   displayName: Notification email
   name: NOTIFY_EMAIL


### PR DESCRIPTION
This patchset adds ability to send user notification with more info
about weekly scan.
    
Added weeklynotify.py module in ccp.notifications module
    
Added subject and body templates in base notification class

Updated the template.yaml to invoke weeklynotify.py module for notifications

Added unittests for weekly notification email module

