### PR TITLE
Ensures built/pulled images are removed on pipeline jobs exit

### DIFF
--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -54,7 +54,11 @@ objects:
                     def image_name = "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def daemonset_name = "scan-data_scan-data"
+                    // setting this to ensure the user is notificatied only after the mandatory stages are complete
+                    // i.e. (checkout, prebuild) - lint - build - scan - deliver
                     def success = false
+                    // setting this to ensure the image is removed from the system if its locally built
+                    def image_is_built = false
                     try {
                         stage('Checkout Source') {
                             checkout([
@@ -97,6 +101,7 @@ objects:
                                 sh "docker build --no-cache -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
                                 sh "docker images"
                             }
+                            image_is_built = true
                         }
                         stage('Scan the image') {
                             parallel (
@@ -122,14 +127,10 @@ objects:
                         stage("Push image to registry") {
                             sh "docker tag ${image_name} ${image_name_with_registry}"
                             sh "docker push ${image_name_with_registry}"
-                        }
-                        // this stage should be triggered after image is delivered to the registry
-                        stage('Remove the image'){
-                            sh "docker rmi ${image_name_with_registry}"
-                            sh "docker rmi ${image_name}"
                             // image lint - build - scan - deliver is successful
                             success = true
                         }
+
                     }
                     finally {
                       stage("Notify user"){
@@ -140,6 +141,16 @@ objects:
                             sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/notify.py failed ${NAMESPACE} `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                             }
                     }
+                      if (image_is_built == true) {
+                        // this stage should be triggered only if image_is_built
+                        // or if image_is_built and there are failures in subsequent stages after building the image
+                        // we need to make sure the image is removed in either case
+                        stage('Remove the image') {
+                          // don't fail the pipeline if image removal failed due to some error
+                          // the dangling images removal should be handled seprately by some cron etc
+                          sh (script: "docker rmi ${image_name_with_registry}; docker rmi ${image_name}", returnStatus: true)
+                        }
+                      }
                   }
               }
             }

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -47,7 +47,11 @@ objects:
                     def image_tags = "http://${REGISTRY_URL}/v2/${APP_ID}/${JOB_ID}/tags/list"
                     def daemonset_name = "scan-data_scan-data"
                     def image_in_registry = false
+                    // setting this to ensure the user is notified correctly if the required stages in weekly scan are complete
                     def success = false
+                    // setting this to ensure the image is removed from the system if its being pulled or/and scanned
+                    def image_is_pulled = false
+
                     try{
                         stage('Check if image exists in registry'){
                             sh "curl ${image_tags} | grep ${DESIRED_TAG}"
@@ -55,6 +59,7 @@ objects:
                         }
                         stage('Pull the docker image'){
                             sh "docker pull ${image_name_with_registry}"
+                            image_is_pulled = true
                         }
                         stage('Scan the image') {
                             parallel (
@@ -76,9 +81,7 @@ objects:
                                   sh "cat capabilities"
                                 }
                             )
-                        }
-                        stage('Remove the docker image'){
-                            sh "docker rmi ${image_name_with_registry}"
+                            // image pull - scan is successful in weeklyscan case
                             success = true
                         }
                     }
@@ -94,10 +97,20 @@ objects:
                           } else {
                             sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ${PIPELINE_REPO_DIR}/ccp/notifications/weeklynotify.py image_absent ${NAMESPACE} `oc get route jenkins -o template --template={{.spec.host}}` ${image_name} ${BUILD_NUMBER} ${PIPELINE_NAME}"
                         }
-                      }
-                    }
-                }
-            }
+
+                          if (image_is_pulled == true) {
+
+                            // this stage should be triggered only if image_is_pulled
+                            // or if image_is_pulled and there are failures in subsequent stage(s) after image is pulled (i.e. scan stage)
+                            // we need to make sure the image is removed in either case
+                            stage('Remove the image') {
+                              sh (script: "docker rmi $image_name_with_registry", returnStatus: true)
+                            }
+                          }
+                        }
+                     }
+                  }
+              }
           env:
           - name: NAMESPACE
             value: ${NAMESPACE}


### PR DESCRIPTION
Puts the `Remove the image` stage in finally block and prevents pipeline's execution status based on mentioned stage's status (i.e. even if it fails, the pipeline's over all status should be `Complete`).

For seed-job/template.yaml :
Ensures locally built image is removed from system in seed-job/template.yaml

Adds `Remove the image` stage in the finally block after `Notify user` stage.
    
Defines a flag image_is_built, and uses it to define the `Remove the image` stage.
    
Don't fail the pipeline if image removal has failed due to some error.

----------------

For weekly-scan/template.yaml : 
Ensures locally pulled image is removed from system in weekly-scan/template.yaml

Adds `Remove the image` stage in the finally block after `Notify user` stage.
    
Defines a flag image_is_pulled, and uses it to define the `Remove the image` stage.
    
Don't fail the pipeline if image removal has failed due to some error.


------------------

Fixes #627 
