### PR TITLE
Stops triggering builds for configChange of master-job template

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -309,11 +309,20 @@ class BuildConfigManager(object):
         # if a buildConfig has config update, oc apply returns
         # "buildconfig.build.openshift.io "$PIPELINE_NAME" configured"
         # possible values are ["unchanged", "created", "configured"]
-        # we are looking for "configured" string for updated pipelines
-        if "configured" in output:
-            _print("{} is updated, starting build..".format(
-                project.pipeline_name))
-            self.start_build(project.pipeline_name)
+        # we are looking for "configured" string for updated pipeline
+        # templates.
+        # Update: 21 Sept 2018 :
+        # We are seeing hundreds of build triggered due to configChange,
+        # which is unnecessary, because configChange can merely be
+        # any parameter change in the template.
+        # The parameters we care about for re-triggering builds are
+        # taken care already by master-job, SCM polling, where each index
+        # entry's git-url and git-branch are already being monitored.
+        # Thus stopping the behavior to start-build of configured pipelines.
+        # if "configured" in output:
+        #    _print("{} is updated, starting build..".format(
+        #        project.pipeline_name))
+        #    self.start_build(project.pipeline_name)
 
     @retry(tries=10, delay=3, backoff=2)
     def apply_weekly_scan(self,


### PR DESCRIPTION
 All the pipelines have master-job template set for building at OpenShift.

 Any single change in template, is identified as configChange by oc.

 In IndexReader, we see if a buildConfig / master-job for pipeline is configured,
 while running seed-job (which syncs index with pipelines on OpenShift).

 Update in tempaltes can be of two types:
  A- Update in parameters which affects the resultant builds
  B- Update in parameters which affects service side workflow and behavior

 The build should only be re-triggered in case A.

 However, those changes as mentioned in A, are already taken
 care by poll SCM config in master-job of pipeline.

 Thus, we need to prevent re-triggering builds in case of B.