### PR TITLE
Gracefully delete the buildConfigs while removing stale projects

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -395,14 +395,17 @@ class BuildConfigManager(object):
         _print(run_cmd(command))
 
     @retry(tries=10, delay=3, backoff=2)
-    def delete_buildconfigs(self, bcs):
+    def delete_buildconfigs(self, bcs, wait_between_delete=5):
         """
         Deletes the given list of bcs
         """
-        command = "oc delete -n {} bc {}"
+        command = ("oc delete -n {} bc {} --ignore-not-found=true "
+                   "--now=true --include-uninitialized=true")
+
         for bc in bcs:
             _print("Deleting buildConfig {}".format(bc))
             run_cmd(command.format(self.namespace, bc))
+            time.sleep(wait_between_delete)
 
     @retry(tries=5, delay=3, backoff=2)
     def list_all_builds(self):


### PR DESCRIPTION
 Index reader identifies stale projects and deletes the respective
 buildConfigs.
 We were deleting all the buildConfigs without grace period between deleting
 all the buildConfigs in identified stale projects list, which could result
 into inconsistencies in the console view of the Projects.
 The projects deleted could still show up on the console.

 In order to avoid this, we have added 5 seconds delay in between deleting the
 stale projects. After deleting each buildConfig from the list of stale buildConfigs,
 index reader sleeps for 5 seconds.

 Also added `--ignore-not-found=true --now=true --include-uninitialized=true` flags.