### PR TITLE
Adds feature to specify custom email subject prefix

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -205,13 +205,15 @@ class BuildConfigManager(object):
     """
 
     def __init__(self, registry_url, namespace, from_address, smtp_server,
-                 ccp_openshift_slave_image, notify_cc_emails):
+                 ccp_openshift_slave_image, notify_cc_emails,
+                 registry_alias):
         self.registry_url = registry_url
         self.namespace = namespace
         self.from_address = from_address
         self.smtp_server = smtp_server
         self.ccp_openshift_slave_image = ccp_openshift_slave_image
         self.notify_cc_emails = notify_cc_emails
+        self.registry_alias = registry_alias
 
         self.template_params = """\
 -p GIT_URL={git_url} \
@@ -223,6 +225,7 @@ class BuildConfigManager(object):
 -p DEPENDS_ON={depends_on} \
 -p NOTIFY_EMAIL={notify_email} \
 -p NOTIFY_CC_EMAILS={notify_cc_emails} \
+-p REGISTRY_ALIAS={registry_alias} \
 -p PIPELINE_NAME={pipeline_name} \
 -p APP_ID={app_id} \
 -p JOB_ID={job_id} \
@@ -240,6 +243,7 @@ class BuildConfigManager(object):
 -p REGISTRY_URL={registry_url} \
 -p NOTIFY_EMAIL={notify_email} \
 -p NOTIFY_CC_EMAILS={notify_cc_emails} \
+-p REGISTRY_ALIAS={registry_alias} \
 -p APP_ID={app_id} \
 -p JOB_ID={job_id} \
 -p DESIRED_TAG={desired_tag} \
@@ -303,6 +307,7 @@ class BuildConfigManager(object):
             smtp_server=self.smtp_server,
             ccp_openshift_slave_image=self.ccp_openshift_slave_image,
             notify_cc_emails=self.notify_cc_emails,
+            registry_alias=self.registry_alias,
         )
         # process and apply buildconfig
         output = run_cmd(command, shell=True)
@@ -361,7 +366,8 @@ class BuildConfigManager(object):
             from_address=self.from_address,
             smtp_server=self.smtp_server,
             ccp_openshift_slave_image=self.ccp_openshift_slave_image,
-            notify_cc_emails=self.notify_cc_emails
+            notify_cc_emails=self.notify_cc_emails,
+            registry_alias=self.registry_alias,
         )
         # process and apply buildconfig
         output = run_cmd(command, shell=True)
@@ -463,6 +469,7 @@ class Index(object):
                  from_address, smtp_server,
                  ccp_openshift_slave_image,
                  notify_cc_emails,
+                 registry_alias,
                  infra_projects=["seed-job"],
                  ci_projects=["ci-success-job", "ci-failure-job"]):
 
@@ -472,7 +479,8 @@ class Index(object):
         # create bc_manager object
         self.bc_manager = BuildConfigManager(
             registry_url, namespace, from_address, smtp_server,
-            ccp_openshift_slave_image, notify_cc_emails)
+            ccp_openshift_slave_image, notify_cc_emails,
+            registry_alias)
 
         # set the infra_projects and ci_projects to be filtered
         # out while removing the stale jobs
@@ -650,7 +658,7 @@ class Index(object):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 11:
+    if len(sys.argv) != 12:
         _print("Incomplete set of input variables, please refer README.")
         sys.exit(1)
 
@@ -664,12 +672,13 @@ if __name__ == "__main__":
     batch_outstanding_builds_cap = int(sys.argv[8].strip())
     ccp_openshift_slave_image = sys.argv[9].strip()
     notify_cc_emails = sys.argv[10].strip()
+    registry_alias = sys.argv[11].strip()
 
     index_object = Index(
         index, registry_url, namespace,
         from_address, smtp_server, ccp_openshift_slave_image,
-        notify_cc_emails
-        )
+        notify_cc_emails, registry_alias
+    )
 
     index_object.run(
         batch_size,

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -49,7 +49,7 @@ objects:
                     }
                     stage('Parse index') {
                         dir("${PIPELINE_REPO_DIR}") {
-                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ccp/index_reader.py ${CONTAINER_INDEX_DIR}/index.d ${REGISTRY_URL} ${NAMESPACE} ${FROM_ADDRESS} ${SMTP_SERVER} ${BATCH_SIZE} ${BATCH_POLLING_INTERVAL} ${BATCH_OUTSTANDING_BUILDS_CAP} ${CCP_OPENSHIFT_SLAVE_IMAGE} ${NOTIFY_CC_EMAILS}"
+                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ccp/index_reader.py ${CONTAINER_INDEX_DIR}/index.d ${REGISTRY_URL} ${NAMESPACE} ${FROM_ADDRESS} ${SMTP_SERVER} ${BATCH_SIZE} ${BATCH_POLLING_INTERVAL} ${BATCH_OUTSTANDING_BUILDS_CAP} ${CCP_OPENSHIFT_SLAVE_IMAGE} ${NOTIFY_CC_EMAILS} ${REGISTRY_ALIAS}"
                         }
                     }
                 }
@@ -73,6 +73,8 @@ objects:
             value: ${BATCH_OUTSTANDING_BUILDS_CAP}
           - name: NOTIFY_CC_EMAILS
             value: ${NOTIFY_CC_EMAILS}
+          - name: REGISTRY_ALIAS
+            value: ${REGISTRY_ALIAS}
       triggers:
           - type: ConfigChange
 parameters:
@@ -116,6 +118,11 @@ parameters:
   displayName: SMTP server address
   name: SMTP_SERVER
   required: true
+- description: Registry alias to be referenced in email subject and body instead of actual REGISTRY_URL
+  displayName: Registry alias to be referenced in email subject and body
+  name: REGISTRY_ALIAS
+  required: false
+  value: "null"
 - description: Number of builds to process in a batch
   displayName: Size of batch
   name: BATCH_SIZE

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -178,6 +178,8 @@ objects:
             value: ${NOTIFY_EMAIL}
           - name: NOTIFY_CC_EMAILS
             value: ${NOTIFY_CC_EMAILS}
+          - name: REGISTRY_ALIAS
+            value: ${REGISTRY_ALIAS}
           - name: DEPENDS_ON
             value: ${DEPENDS_ON}
           - name: BUILD_CONTEXT
@@ -224,6 +226,11 @@ parameters:
 - description: Comma separated email addresses to add in Cc
   displayName: Notification Cc emails
   name: NOTIFY_CC_EMAILS
+  required: false
+  value: "null"
+- description: Registry alias to be referenced in email subject and body instead of actual REGISTRY_URL
+  displayName: Registry alias to be referenced in email subject and body
+  name: REGISTRY_ALIAS
   required: false
   value: "null"
 - description: Parent image for the project

--- a/tests/test_00_unit/test_01_notifications/__init__.py
+++ b/tests/test_00_unit/test_01_notifications/__init__.py
@@ -15,8 +15,8 @@ class TestNotify(unittest.TestCase):
     def setUp(self):
         self.notify_obj = notify.BuildNotify()
         self.image_name = "a/b:c"
-        self.registry = "registry.centos.org"
-        self.email_subject_prefix = "null"
+        self.registry_url = "registry.centos.org"
+        self.registry_alias = "null"
 
     def test_subject_of_email_1(self):
         """
@@ -25,10 +25,13 @@ class TestNotify(unittest.TestCase):
         # Check the SUCCESS case
         self.assertEqual(
             self.notify_obj.subject_of_email(
-                True, self.image_name, self.registry,
-                self.email_subject_prefix),
+                True,
+                self.image_name,
+                self.registry_url,
+                self.registry_alias),
             "[{}] SUCCESS: Container build {}".format(
-                self.registry, self.image_name))
+                self.registry_url,
+                self.image_name))
 
     def test_subject_of_email_2(self):
         """
@@ -41,7 +44,7 @@ class TestNotify(unittest.TestCase):
         self.assertEqual(
             self.notify_obj.subject_of_email(
                 True, self.image_name, self.registry,
-                self.email_subject_prefix),
+                self.registry_alias),
             # using registry name without port
             "[registry.centos.org] SUCCESS: Container build {}".format(
                 self.image_name))
@@ -53,10 +56,13 @@ class TestNotify(unittest.TestCase):
         # Check the FAILED case
         self.assertEqual(
             self.notify_obj.subject_of_email(
-                False, self.image_name, self.registry,
-                self.email_subject_prefix),
+                False,
+                self.image_name,
+                self.registry_url,
+                self.registry_alias),
             "[{}] FAILED: Container build {}".format(
-                self.registry, self.image_name))
+                self.registry_url,
+                self.image_name))
 
     def test_body_of_email(self):
         """
@@ -65,11 +71,10 @@ class TestNotify(unittest.TestCase):
 
         # check the SUCCESS case
         status = "Success"
-        repository = "registry.centos.org/foo/bar"
         cause = "Started by admin"
         expected_value = """\
 Build Status:                 Success
-Repository:                   registry.centos.org/foo/bar
+Repository:                   https://registry.centos.org/a/b
 Cause of build:               Started by admin
 
 --
@@ -81,8 +86,10 @@ https://wiki.centos.org/ContainerPipeline
         self.assertEqual(
             self.notify_obj.body_of_email(
                 status,
-                repository,
-                cause),
+                self.image_name,
+                cause,
+                self.registry_url,
+                self.registry_alias),
             expected_value)
 
 

--- a/tests/test_00_unit/test_01_notifications/__init__.py
+++ b/tests/test_00_unit/test_01_notifications/__init__.py
@@ -16,6 +16,7 @@ class TestNotify(unittest.TestCase):
         self.notify_obj = notify.BuildNotify()
         self.image_name = "a/b:c"
         self.registry = "registry.centos.org"
+        self.email_subject_prefix = "null"
 
     def test_subject_of_email_1(self):
         """
@@ -24,7 +25,8 @@ class TestNotify(unittest.TestCase):
         # Check the SUCCESS case
         self.assertEqual(
             self.notify_obj.subject_of_email(
-                True, self.image_name, self.registry),
+                True, self.image_name, self.registry,
+                self.email_subject_prefix),
             "[{}] SUCCESS: Container build {}".format(
                 self.registry, self.image_name))
 
@@ -38,7 +40,8 @@ class TestNotify(unittest.TestCase):
         # Check the SUCCESS case
         self.assertEqual(
             self.notify_obj.subject_of_email(
-                True, self.image_name, self.registry),
+                True, self.image_name, self.registry,
+                self.email_subject_prefix),
             # using registry name without port
             "[registry.centos.org] SUCCESS: Container build {}".format(
                 self.image_name))
@@ -50,7 +53,8 @@ class TestNotify(unittest.TestCase):
         # Check the FAILED case
         self.assertEqual(
             self.notify_obj.subject_of_email(
-                False, self.image_name, self.registry),
+                False, self.image_name, self.registry,
+                self.email_subject_prefix),
             "[{}] FAILED: Container build {}".format(
                 self.registry, self.image_name))
 

--- a/tests/test_00_unit/test_01_notifications/test_weeklynotify.py
+++ b/tests/test_00_unit/test_01_notifications/test_weeklynotify.py
@@ -14,6 +14,9 @@ class TestWeeklyNotify(unittest.TestCase):
 
     def setUp(self):
         self.notify_obj = weeklynotify.WeeklyScanNotify()
+        self.image_name = "foo/bar:latest"
+        self.registry_url = "registry.centos.org"
+        self.registry_alias = "null"
 
     def test_body_of_email(self):
         """
@@ -21,7 +24,6 @@ class TestWeeklyNotify(unittest.TestCase):
         """
 
         status = True
-        repository = "https://registry.centos.org/foo/bar"
         expected_value = """\
 Scan status:                  Success
 Repository:                   https://registry.centos.org/foo/bar
@@ -34,7 +36,9 @@ https://wiki.centos.org/ContainerPipeline
         self.assertEqual(
             self.notify_obj.body_of_email(
                 status,
-                repository),
+                self.image_name,
+                self.registry_url,
+                self.registry_alias),
             expected_value)
 
     def test_image_absent_email_body(self):

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -136,6 +136,8 @@ objects:
             value: ${FROM_ADDRESS}
           - name: SMTP_SERVER
             value: ${SMTP_SERVER}
+          - name: REGISTRY_ALIAS
+            value: ${REGISTRY_ALIAS}
 parameters:
 - description: Namespace to which the resulting Jenkins Pipelines should belong
   displayName: OpenShift namespace
@@ -148,6 +150,11 @@ parameters:
 - description: Comma separated email addresses to add in Cc
   displayName: Notification Cc emails
   name: NOTIFY_CC_EMAILS
+  required: false
+  value: "null"
+- description: Registry alias to be referenced in email subject and body instead of actual REGISTRY_URL
+  displayName: Registry alias to be referenced in email subject and body
+  name: REGISTRY_ALIAS
   required: false
   value: "null"
 - description: Name of the Pipeline as we want to show up on OpenShift console


### PR DESCRIPTION
This PR adds feature to specify custom email subject prefix, which will be used while sending user email notifications.

The parameter to specify the prefix is `EMAIL_SUBJECT_PREFIX`. Its an optional parameter. If its not given while creating seed-job, the default behavior is applied to email notifications.
In default behavior, the configured registry (without port) is added in email subject prefix.