### PR TITLE
Fixes scanners' invocation in scan stage in weekly scan template

### DIFF
--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -64,20 +64,20 @@ objects:
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
                                   sh "cat yum-check-update"
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
                                   sh "cat rpm-verify"
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
                                   sh "cat misc-updates"
                                 },
                                 "Container capabilities": {
                                   def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
                                   sh "cat capabilities"
                                 }
                             )


### PR DESCRIPTION
 This changeset fixes the way we invoke the scanners.

 - Adds --user root option to docker run command. This fixes
   yum updates scanner to have right permission while performing yum
   related tasks.

 - Updates the absolute path of python binary in entrypoint option to
   /usr/bin/python. This makes the scanners compatible to run against
   RHEL6 based images.

 - References the $image_name_with_registry while invoking the scans.
   Earlier $image_name was referenced - which could be pulling the same
   image *again* from configured registry, beside it has already pulled the
   image in earlier stage.