### PR TITLE
Specify resource requests in pod template

### DIFF
--- a/ccp/index_reader.py
+++ b/ccp/index_reader.py
@@ -206,7 +206,7 @@ class BuildConfigManager(object):
 
     def __init__(self, registry_url, namespace, from_address, smtp_server,
                  ccp_openshift_slave_image, notify_cc_emails,
-                 registry_alias):
+                 registry_alias, master_job_cpu, master_job_memory):
         self.registry_url = registry_url
         self.namespace = namespace
         self.from_address = from_address
@@ -214,6 +214,8 @@ class BuildConfigManager(object):
         self.ccp_openshift_slave_image = ccp_openshift_slave_image
         self.notify_cc_emails = notify_cc_emails
         self.registry_alias = registry_alias
+        self.master_job_cpu = master_job_cpu
+        self.master_job_memory = master_job_memory
 
         self.template_params = """\
 -p GIT_URL={git_url} \
@@ -226,6 +228,8 @@ class BuildConfigManager(object):
 -p NOTIFY_EMAIL={notify_email} \
 -p NOTIFY_CC_EMAILS={notify_cc_emails} \
 -p REGISTRY_ALIAS={registry_alias} \
+-p MASTER_JOB_CPU={master_job_cpu} \
+-p MASTER_JOB_MEMORY={master_job_memory} \
 -p PIPELINE_NAME={pipeline_name} \
 -p APP_ID={app_id} \
 -p JOB_ID={job_id} \
@@ -308,6 +312,8 @@ class BuildConfigManager(object):
             ccp_openshift_slave_image=self.ccp_openshift_slave_image,
             notify_cc_emails=self.notify_cc_emails,
             registry_alias=self.registry_alias,
+            master_job_cpu=self.master_job_cpu,
+            master_job_memory=self.master_job_memory
         )
         # process and apply buildconfig
         output = run_cmd(command, shell=True)
@@ -470,6 +476,7 @@ class Index(object):
                  ccp_openshift_slave_image,
                  notify_cc_emails,
                  registry_alias,
+                 master_job_cpu, master_job_memory,
                  infra_projects=["seed-job"],
                  ci_projects=["ci-success-job", "ci-failure-job"]):
 
@@ -480,7 +487,7 @@ class Index(object):
         self.bc_manager = BuildConfigManager(
             registry_url, namespace, from_address, smtp_server,
             ccp_openshift_slave_image, notify_cc_emails,
-            registry_alias)
+            registry_alias, master_job_cpu, master_job_memory)
 
         # set the infra_projects and ci_projects to be filtered
         # out while removing the stale jobs
@@ -658,7 +665,7 @@ class Index(object):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 12:
+    if len(sys.argv) != 14:
         _print("Incomplete set of input variables, please refer README.")
         sys.exit(1)
 
@@ -673,11 +680,13 @@ if __name__ == "__main__":
     ccp_openshift_slave_image = sys.argv[9].strip()
     notify_cc_emails = sys.argv[10].strip()
     registry_alias = sys.argv[11].strip()
+    master_job_cpu = sys.argv[12].strip()
+    master_job_memory = sys.argv[13].strip()
 
     index_object = Index(
         index, registry_url, namespace,
         from_address, smtp_server, ccp_openshift_slave_image,
-        notify_cc_emails, registry_alias
+        notify_cc_emails, registry_alias, master_job_cpu, master_job_memory
     )
 
     index_object.run(

--- a/docs/install-service/setup-openshift-372.md
+++ b/docs/install-service/setup-openshift-372.md
@@ -120,7 +120,9 @@ Once the VMs are properly setup and NFS is exported, it’s time to setup the cl
 
 ## Setup Ansible Controller
 
-Please ensure atleast ansible 2.4.3 is installed. In case of CentOS 7 nodes, 2.4.3 is not available in default repositories, but you may install and install openshift-ansible RPM on Ansible controller VM.
+Please ensure atleast ansible 2.4.3 is installed. In case of CentOS 7 nodes,
+2.4.3 is not available in default repositories, but you may install that and
+`openshift-ansible` RPM on Ansible controller VM.
 
 ```bash
 $ yum install http://cbs.centos.org/kojifiles/packages/ansible/2.4.3.0/1.el7/noarch/ansible-2.4.3.0-1.el7.noarch.rpm
@@ -422,18 +424,22 @@ $ docker push ${CCP_OPENSHIFT_SLAVE_IMAGE}
 
 Finally create the Jenkins Pipeline build to parse the container-index. This will create a
 seed-job which will parse the container index and create more Jenkins Pipeline builds
-that will create the actual container images for projects covered in the index. Replace
-172.29.33.8 with the IP address of your remote registry (you need to configure external
-registry by yourself, you can use the NFS VM created for same). Replace  master with the branch you’d like to deploy.
+that will create the actual container images for projects covered in the index. 
 
 ```bash
-$ oc process -p CONTAINER_INDEX_REPO=${CONTAINER_INDEX_REPO}\
-     -p CONTAINER_INDEX_BRANCH=${CONTAINER_INDEX_BRANCH}\
-     -p REGISTRY_URL=${REGISTRY_URL}\
+$ oc process -p CONTAINER_INDEX_REPO=${CONTAINER_INDEX_REPO} \
+     -p CONTAINER_INDEX_BRANCH=${CONTAINER_INDEX_BRANCH} \
+     -p REGISTRY_URL=${REGISTRY_URL} \
      -p NAMESPACE=`oc project -q`\
-     -p FROM_ADDRESS=${FROM_ADDRESS}\
-     -p SMTP_SERVER=${SMTP_SERVER}\
-     -p CCP_OPENSHIFT_SLAVE_IMAGE=${CCP_OPENSHIFT_SLAVE_IMAGE}\
+     -p FROM_ADDRESS=${FROM_ADDRESS} \
+     -p SMTP_SERVER=${SMTP_SERVER} \
+     -p CCP_OPENSHIFT_SLAVE_IMAGE=${CCP_OPENSHIFT_SLAVE_IMAGE} \
+     -p NOTIFY_CC_EMAILS=${NOTIFY_CC_EMAILS} \
+     -p BATCH_SIZE=${BATCH_SIZE} \
+     -p SEED_JOB_CPU=${SEED_JOB_CPU} \
+     -p SEED_JOB_MEMORY=${SEED_JOB_MEMORY} \
+     -p MASTER_JOB_CPU=${MASTER_JOB_CPU} \
+     -p MASTER_JOB_MEMORY=${MASTER_JOB_MEMORY} \
      -f seed-job/buildtemplate.yaml | oc create -f -
 ```
 This is of course, the bare minimum. To use more parameters, just add more -p
@@ -458,6 +464,10 @@ if nothing is provided:
 | BATCH_SIZE                   | True     | 5                                                              | Number of builds to process in a batch. Increase if you have resources.                                                                                         |
 | BATCH_POLLING_INTERVAL       | True     | 30                                                             | Polling interval (in seconds) between two batches to check if any builds are outstanding. Increase if you need more delay.                                      |
 | BATCH_OUTSTANDING_BUILDS_CAP | True     | 3                                                              | If these many builds are still pending, next batch will not be processed.                                                                                       |
+| SEED_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start seed-job slave pod  |
+| SEED_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start seed-job slave pod
+| MASTER_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start master-job slave pod  |
+| MASTER_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start master-job slave pod
 
 
 #### Create weekly-scan scheduler

--- a/docs/install-service/setup-openshift-372.md
+++ b/docs/install-service/setup-openshift-372.md
@@ -464,10 +464,10 @@ if nothing is provided:
 | BATCH_SIZE                   | True     | 5                                                              | Number of builds to process in a batch. Increase if you have resources.                                                                                         |
 | BATCH_POLLING_INTERVAL       | True     | 30                                                             | Polling interval (in seconds) between two batches to check if any builds are outstanding. Increase if you need more delay.                                      |
 | BATCH_OUTSTANDING_BUILDS_CAP | True     | 3                                                              | If these many builds are still pending, next batch will not be processed.                                                                                       |
-| SEED_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start seed-job slave pod  |
-| SEED_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start seed-job slave pod
-| MASTER_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start master-job slave pod  |
-| MASTER_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start master-job slave pod
+| SEED_JOB_CPU                 | True     | 1 | Number of CPUs to be requested from OpenShift to start seed-job slave pod  |
+| SEED_JOB_MEMORY | True  | 1 GiB | Amount of memory to be requested from OpenShift to start seed-job slave pod
+| MASTER_JOB_CPU                 | True     | 1 | Number of CPUs to be requested from OpenShift to start master-job slave pod  |
+| MASTER_JOB_MEMORY | True  | 1 GiB | Amount of memory to be requested from OpenShift to start master-job slave pod
 
 
 #### Create weekly-scan scheduler

--- a/docs/install-service/setup-openshift-390.md
+++ b/docs/install-service/setup-openshift-390.md
@@ -465,9 +465,9 @@ if nothing is provided:
 | BATCH_SIZE                   | True     | 5                                                              | Number of builds to process in a batch. Increase if you have resources.                                                                                         |
 | BATCH_POLLING_INTERVAL       | True     | 30                                                             | Polling interval (in seconds) between two batches to check if any builds are outstanding. Increase if you need more delay.                                      |
 | BATCH_OUTSTANDING_BUILDS_CAP | True     | 3                                                              | If these many builds are still pending, next batch will not be processed.                                                                                       |
-| SEED_JOB_CPU                 | True     | None/Must override    | Amount of CPU to be requested from OpenShift to start seed-job slave pod  |
+| SEED_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start seed-job slave pod  |
 | SEED_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start seed-job slave pod
-| MASTER_JOB_CPU                 | True     | None/Must override    | Amount of CPU to be requested from OpenShift to start master-job slave pod  |
+| MASTER_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start master-job slave pod  |
 | MASTER_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start master-job slave pod
 
 #### Create weekly-scan scheduler

--- a/docs/install-service/setup-openshift-390.md
+++ b/docs/install-service/setup-openshift-390.md
@@ -22,10 +22,10 @@ contents:
 
 ```bash
 
-$ cat ~/bin/script.sh 
+$ cat ~/bin/script.sh
 sudo bash -c 'echo "<SSH public key of Ansible controller host>" >> ~/.ssh/authorized_keys'
 
-$ cat ~/bin/os_cluster.sh 
+$ cat ~/bin/os_cluster.sh
 #!/bin/bash
 
 echo "" !> ~/.ssh/known_hosts
@@ -120,7 +120,9 @@ Once the VMs are properly setup and NFS is exported, it’s time to setup the cl
 
 ## Setup Ansible Controller
 
-Please ensure atleast ansible 2.4.3 is installed. In case of CentOS 7 nodes, 2.4.3 is not available in default repositories, but you may install and install openshift-ansible RPM on Ansible controller VM. 
+Please ensure atleast ansible 2.4.3 is installed. In case of CentOS 7 nodes,
+2.4.3 is not available in default repositories, but you may install that and
+`openshift-ansible` RPM on Ansible controller VM.
 
 ```bash
 $ yum install http://cbs.centos.org/kojifiles/packages/ansible/2.4.3.0/1.el7/noarch/ansible-2.4.3.0-1.el7.noarch.rpm
@@ -423,18 +425,22 @@ $ docker push ${CCP_OPENSHIFT_SLAVE_IMAGE}
 
 Finally create the Jenkins Pipeline build to parse the container-index. This will create a
 seed-job which will parse the container index and create more Jenkins Pipeline builds
-that will create the actual container images for projects covered in the index. Replace
-172.29.33.8 with the IP address of your remote registry (you need to configure external
-registry by yourself, you can use the NFS VM created for same). Replace  master with the branch you’d like to deploy.
+that will create the actual container images for projects covered in the index. 
 
 ```bash
-$ oc process -p CONTAINER_INDEX_REPO=${CONTAINER_INDEX_REPO}\
-     -p CONTAINER_INDEX_BRANCH=${CONTAINER_INDEX_BRANCH}\
-     -p REGISTRY_URL=${REGISTRY_URL}\
+$ oc process -p CONTAINER_INDEX_REPO=${CONTAINER_INDEX_REPO} \
+     -p CONTAINER_INDEX_BRANCH=${CONTAINER_INDEX_BRANCH} \
+     -p REGISTRY_URL=${REGISTRY_URL} \
      -p NAMESPACE=`oc project -q`\
-     -p FROM_ADDRESS=${FROM_ADDRESS}\
-     -p SMTP_SERVER=${SMTP_SERVER}\
-     -p CCP_OPENSHIFT_SLAVE_IMAGE=${CCP_OPENSHIFT_SLAVE_IMAGE}\
+     -p FROM_ADDRESS=${FROM_ADDRESS} \
+     -p SMTP_SERVER=${SMTP_SERVER} \
+     -p CCP_OPENSHIFT_SLAVE_IMAGE=${CCP_OPENSHIFT_SLAVE_IMAGE} \
+     -p NOTIFY_CC_EMAILS=${NOTIFY_CC_EMAILS} \
+     -p BATCH_SIZE=${BATCH_SIZE} \
+     -p SEED_JOB_CPU=${SEED_JOB_CPU} \
+     -p SEED_JOB_MEMORY=${SEED_JOB_MEMORY} \
+     -p MASTER_JOB_CPU=${MASTER_JOB_CPU} \
+     -p MASTER_JOB_MEMORY=${MASTER_JOB_MEMORY} \
      -f seed-job/buildtemplate.yaml | oc create -f -
 ```
 This is of course, the bare minimum. To use more parameters, just add more -p
@@ -459,6 +465,10 @@ if nothing is provided:
 | BATCH_SIZE                   | True     | 5                                                              | Number of builds to process in a batch. Increase if you have resources.                                                                                         |
 | BATCH_POLLING_INTERVAL       | True     | 30                                                             | Polling interval (in seconds) between two batches to check if any builds are outstanding. Increase if you need more delay.                                      |
 | BATCH_OUTSTANDING_BUILDS_CAP | True     | 3                                                              | If these many builds are still pending, next batch will not be processed.                                                                                       |
+| SEED_JOB_CPU                 | True     | None/Must override    | Amount of CPU to be requested from OpenShift to start seed-job slave pod  |
+| SEED_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start seed-job slave pod
+| MASTER_JOB_CPU                 | True     | None/Must override    | Amount of CPU to be requested from OpenShift to start master-job slave pod  |
+| MASTER_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start master-job slave pod
 
 #### Create weekly-scan scheduler
 

--- a/docs/install-service/setup-openshift-390.md
+++ b/docs/install-service/setup-openshift-390.md
@@ -465,10 +465,10 @@ if nothing is provided:
 | BATCH_SIZE                   | True     | 5                                                              | Number of builds to process in a batch. Increase if you have resources.                                                                                         |
 | BATCH_POLLING_INTERVAL       | True     | 30                                                             | Polling interval (in seconds) between two batches to check if any builds are outstanding. Increase if you need more delay.                                      |
 | BATCH_OUTSTANDING_BUILDS_CAP | True     | 3                                                              | If these many builds are still pending, next batch will not be processed.                                                                                       |
-| SEED_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start seed-job slave pod  |
-| SEED_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start seed-job slave pod
-| MASTER_JOB_CPU                 | True     | None/Must override    | Number of CPUs to be requested from OpenShift to start master-job slave pod  |
-| MASTER_JOB_MEMORY | True  | None/Must override | Amount of memory to be requested from OpenShift to start master-job slave pod
+| SEED_JOB_CPU                 | True     | 1    | Number of CPUs to be requested from OpenShift to start seed-job slave pod  |
+| SEED_JOB_MEMORY | True  | 1 GiB | Amount of memory to be requested from OpenShift to start seed-job slave pod
+| MASTER_JOB_CPU                 | True     | 1 | Number of CPUs to be requested from OpenShift to start master-job slave pod  |
+| MASTER_JOB_MEMORY | True  | 1 GiB | Amount of memory to be requested from OpenShift to start master-job slave pod
 
 #### Create weekly-scan scheduler
 

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -152,7 +152,7 @@ parameters:
   displayName: seed job CPU
   name: SEED_JOB_CPU
   required: true
-  value: 1
+  value: "1"
 - description: Amount of memory to be requested from OpenShift to start seed-job slave pod
   displayName: seed job memory
   name: SEED_JOB_MEMORY
@@ -162,7 +162,7 @@ parameters:
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true
-  value: 1
+  value: "1"
 - description: Amount of memory to be requested from OpenShift to start master-job slave pod
   displayName: master job memory
   name: MASTER_JOB_MEMORY

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -148,7 +148,7 @@ parameters:
   name: CCP_OPENSHIFT_SLAVE_IMAGE
   required: true
   value: registry.centos.org/pipeline-images/ccp-openshift-slave:latest
-- description: Amount of CPU to be requested from OpenShift to start seed-job slave pod
+- description: Number of CPUs to be requested from OpenShift to start seed-job slave pod
   displayName: seed job CPU
   name: SEED_JOB_CPU
   required: true
@@ -156,7 +156,7 @@ parameters:
   displayName: seed job memory
   name: SEED_JOB_MEMORY
   required: true
-- description: Amount of CPU to be requested from OpenShift to start master-job slave pod
+- description: Number of CPUs to be requested from OpenShift to start master-job slave pod
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -36,7 +36,9 @@ objects:
                     alwaysPullImage: true,
                     workingDir: '/tmp',
                     privileged: true,
-                    args: '${computer.jnlpmac} ${computer.name}'
+                    args: '${computer.jnlpmac} ${computer.name}',
+                    resourceRequestCpu: '${SEED_JOB_CPU}',
+                    resourceRequestMemory: '${SEED_JOB_MEMORY}'
                   )
                 ],
             )
@@ -49,7 +51,7 @@ objects:
                     }
                     stage('Parse index') {
                         dir("${PIPELINE_REPO_DIR}") {
-                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ccp/index_reader.py ${CONTAINER_INDEX_DIR}/index.d ${REGISTRY_URL} ${NAMESPACE} ${FROM_ADDRESS} ${SMTP_SERVER} ${BATCH_SIZE} ${BATCH_POLLING_INTERVAL} ${BATCH_OUTSTANDING_BUILDS_CAP} ${CCP_OPENSHIFT_SLAVE_IMAGE} ${NOTIFY_CC_EMAILS} ${REGISTRY_ALIAS}"
+                            sh "PYTHONPATH=${PIPELINE_REPO_DIR} python ccp/index_reader.py ${CONTAINER_INDEX_DIR}/index.d ${REGISTRY_URL} ${NAMESPACE} ${FROM_ADDRESS} ${SMTP_SERVER} ${BATCH_SIZE} ${BATCH_POLLING_INTERVAL} ${BATCH_OUTSTANDING_BUILDS_CAP} ${CCP_OPENSHIFT_SLAVE_IMAGE} ${NOTIFY_CC_EMAILS} ${REGISTRY_ALIAS} ${MASTER_JOB_CPU} ${MASTER_JOB_MEMORY}"
                         }
                     }
                 }
@@ -145,3 +147,19 @@ parameters:
   name: CCP_OPENSHIFT_SLAVE_IMAGE
   required: true
   value: registry.centos.org/pipeline-images/ccp-openshift-slave:latest
+- description: Amount of CPU to be requested from OpenShift to start seed-job slave pod
+  displayName: seed job CPU
+  name: SEED_JOB_CPU
+  required: true
+- description: Amount of memory to be requested from OpenShift to start seed-job slave pod
+  displayName: seed job memory
+  name: SEED_JOB_MEMORY
+  required: true
+- description: Amount of CPU to be requested from OpenShift to start master-job slave pod
+  displayName: master job CPU
+  name: MASTER_JOB_CPU
+  required: true
+- description: Amount of memory to be requested from OpenShift to start master-job slave pod
+  displayName: master job memory
+  name: MASTER_JOB_MEMORY
+  required: true

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -152,15 +152,19 @@ parameters:
   displayName: seed job CPU
   name: SEED_JOB_CPU
   required: true
+  value: 1
 - description: Amount of memory to be requested from OpenShift to start seed-job slave pod
   displayName: seed job memory
   name: SEED_JOB_MEMORY
   required: true
+  value: 1GiB
 - description: Number of CPUs to be requested from OpenShift to start master-job slave pod
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true
+  value: 1
 - description: Amount of memory to be requested from OpenShift to start master-job slave pod
   displayName: master job memory
   name: MASTER_JOB_MEMORY
   required: true
+  value: 1GiB

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -157,7 +157,7 @@ parameters:
   displayName: seed job memory
   name: SEED_JOB_MEMORY
   required: true
-  value: 1GiB
+  value: 1Gi
 - description: Number of CPUs to be requested from OpenShift to start master-job slave pod
   displayName: master job CPU
   name: MASTER_JOB_CPU
@@ -167,4 +167,4 @@ parameters:
   displayName: master job memory
   name: MASTER_JOB_MEMORY
   required: true
-  value: 1GiB
+  value: 1Gi

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -27,6 +27,7 @@ objects:
                 cloud: 'openshift',
                 name: 'ccp-pipeline-seed',
                 label: 'ccp-pipeline-seed',
+                namespace: '${NAMESPACE}',
                 serviceAccount: 'jenkins',
                 containers: [
                   containerTemplate(

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -304,7 +304,7 @@ parameters:
   name: CCP_OPENSHIFT_SLAVE_IMAGE
   required: true
   value: registry.centos.org/pipeline-images/ccp-openshift-slave:latest
-- description: Amount of CPU to be requested from OpenShift to start master-job slave pod
+- description: Number of CPUs to be requested from OpenShift to start master-job slave pod
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -308,9 +308,7 @@ parameters:
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true
-  value: "1"
 - description: Amount of memory to be requested from OpenShift to start master-job slave pod
   displayName: master job memory
   name: MASTER_JOB_MEMORY
   required: true
-  value: 1GiB

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -308,7 +308,7 @@ parameters:
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true
-  value: 1
+  value: "1"
 - description: Amount of memory to be requested from OpenShift to start master-job slave pod
   displayName: master job memory
   name: MASTER_JOB_MEMORY

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -308,7 +308,9 @@ parameters:
   displayName: master job CPU
   name: MASTER_JOB_CPU
   required: true
+  value: 1
 - description: Amount of memory to be requested from OpenShift to start master-job slave pod
   displayName: master job memory
   name: MASTER_JOB_MEMORY
   required: true
+  value: 1GiB

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -30,6 +30,7 @@ objects:
                 cloud: 'openshift',
                 name: 'ccp-pipeline-master',
                 label: 'ccp-pipeline-master',
+                namespace: '${NAMESPACE}',
                 serviceAccount: 'jenkins',
                 containers: [
                   containerTemplate(

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -39,7 +39,9 @@ objects:
                     alwaysPullImage: true,
                     workingDir: '/tmp',
                     privileged: true,
-                    args: '${computer.jnlpmac} ${computer.name}'
+                    args: '${computer.jnlpmac} ${computer.name}',
+                    resourceRequestCpu: '${MASTER_JOB_CPU}',
+                    resourceRequestMemory: '${MASTER_JOB_MEMORY}'
                   )
                 ],
                 volumes: [
@@ -301,3 +303,11 @@ parameters:
   name: CCP_OPENSHIFT_SLAVE_IMAGE
   required: true
   value: registry.centos.org/pipeline-images/ccp-openshift-slave:latest
+- description: Amount of CPU to be requested from OpenShift to start master-job slave pod
+  displayName: master job CPU
+  name: MASTER_JOB_CPU
+  required: true
+- description: Amount of memory to be requested from OpenShift to start master-job slave pod
+  displayName: master job memory
+  name: MASTER_JOB_MEMORY
+  required: true


### PR DESCRIPTION
This PR adds resource requests for Jenkins slave pods which will ensure that a Jenkins slave pod spins up on an OpenShift node if and only if the resources it needs are available.

Long term, we can see how this behaves when a base image with numerous child images is rebuilt and the subsequent child rebuilds are handled. If it works well, we can possibly get away from reliance on batch processing.