### PR TITLE
[DoNotMerge]Adds CCCP readonly API specifications

### DIFF
--- a/ccp/apis/swagger_ccp_apis.yaml
+++ b/ccp/apis/swagger_ccp_apis.yaml
@@ -1,0 +1,380 @@
+swagger: '2.0'
+info:
+  title: 'APIs CentOS Community Container Pipeline Service'
+  description: 'This document serves as API sepcification design document for CentOS Contianer Pipeline service. Purpose of APIs- Serve the project and build information - viz [names, status, logs, etc]. Consumer of APIs -  Registry UI https://registry.centos.org, This will use the APIs to show build information - viz [build names, logs, Dockerfile, etc].'
+  version: 1.0.0
+host: registry.centos.org
+basePath: /api/v1/
+consumes:
+  - application/json
+produces:
+  - application/json
+schemes:
+  - https
+tags:
+  - name: infra
+    description: 'APIs serving infra related information as liveness, help.'
+  - name: meta
+    description: 'APIs serving meta information for projects, namespaces, etc.'
+  - name: projects
+    description: APIs serving details about projects indexed for building.
+  - name: builds
+    description: APIs serving details about builds of projects in service.
+paths:
+  /liveness:
+    get:
+      tags:
+        - infra
+      summary: Get the liveness of API service
+      description: ''
+      operationId: ccp.apis.v1.liveness
+      responses:
+        '200':
+          description: Service is alive.
+          schema:
+            $ref: '#/definitions/Status'
+  /help:
+    get:
+      tags:
+        - infra
+      summary: Get the API documentation
+      description: ''
+      operationId: ccp.apis.v1.help
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ApiDoc'
+        '404':
+          description: Docs not found
+          schema:
+            $ref: '#/definitions/Meta'
+  /namespaces:
+    get:
+      tags:
+        - meta
+      summary: Get all available namespaces accessible over APIs
+      description: ''
+      operationId: ccp.apis.v1.namespaces
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Namespaces'
+        '404':
+          description: No namespaces found
+          schema:
+            $ref: '#/definitions/Meta'
+  /$namespace/projects:
+    get:
+      tags:
+        - meta
+      summary: Get all the projects in given namespace.
+      description: ''
+      operationId: ccp.apis.v1.projects
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Projects'
+  /$namespace/$app-id/$job-id/$desired-tag/metadata:
+    get:
+      tags:
+        - projects
+      summary: Get the metadata of the given project name.
+      description: Get all the metadata of project as provided in container index.
+      operationId: ccp.apis.v1.metadata
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ProjectMetadata'
+  /$namespace/$app_id/$job_id/desired-tags:
+    get:
+      tags:
+        - projects
+      summary: Get tags for given $app_id/$job_id with build status and image
+      description: Get all the tags defined for given $app_id/$job_id along with latest build status and image
+      operationId: ccp.apis.v1.desired_tags
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/AppIdJobIdTags'
+  /$namespace/$app-id/$job-id/$desired-tag/target-file:
+    get:
+      tags:
+        - projects
+      summary: Get Dockerfile for given project
+      description: Get Dockerfile for given project
+      operationId: ccp.apis.v1.target_file
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/TargetFile'
+  /$namespace/$app-id/$job-id/$desired-tag/builds:
+    get:
+      tags:
+        - builds
+      summary: Get all the builds info for given project
+      description: 'Get all the builds number, name and status'
+      operationId: ccp.apis.v1.builds
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ProjectBuildsInfo'
+  /$namespace/$app-id/$job-id/$desired-tag/wscan-builds:
+    get:
+      tags:
+        - builds
+      summary: Get all the weekly scan builds info for given project
+      description: Get all the weekly scan builds info for given project
+      operationId: ccp.apis.v1.wscan_builds
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WeeklyScanBuildsInfo'
+  /$namespace/$app-id/$job-id/$desired-tag/$build/build-logs:
+    get:
+      tags:
+        - builds
+      summary: Get the referenced build logs
+      description: Get the referenced build logs
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BuildLogs'
+  /$namespace/$app-id/$job-id/$desired-tag/$build/wscan-logs:
+    get:
+      tags:
+        - builds
+      summary: Get the referenced wscan build logs
+      description: Get the referenced wscan build logs
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WeeklyScanLogs'
+definitions:
+  Meta:
+    title: Meta info about APIs
+    description: List apiVersion and timestamp of the API request
+    properties:
+      apiVersion:
+        type: string
+      timestamp:
+        type: string
+  Status:
+    title: Status of API server
+    description: Status of API server
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      status:
+        type: string
+  ApiDoc:
+    title: API document
+    description: Api Documentation
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      docs:
+        type: object
+  Namespaces:
+    title: List of available OpenShift namespaces
+    description: List of readable namespaces by API server
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      namespaces:
+        type: array
+        items:
+          type: string
+  Project:
+    title: Basic information about a project
+    description: Basic information about a project
+    properties:
+      app_id:
+        type: string
+      job_id:
+        type: string
+      desired_tag:
+        type: string
+      name:
+        type: string
+  Projects:
+    title: List of all the projects in given namespace
+    description: List of all projects in given namespace
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      projects:
+        type: array
+        items:
+          $ref: '#/definitions/Project'
+  ProjectMetadata:
+    title: List all the info about project as provided in container index
+    description: List all the info about project as provided in container index
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      app_id:
+        type: string
+      job_id:
+        type: string
+      desired_tag:
+        type: string
+      git_url:
+        type: string
+      git_branch:
+        type: string
+      git_path:
+        type: string
+      target_file:
+        type: string
+      build_context:
+        type: string
+      notify_email:
+        type: string
+      depends_on:
+        type: string
+      prebuild_script:
+        type: string
+      prebuild_context:
+        type: string
+  AppIdJobIdTag:
+    title: Tag for given $app_id/$job_id with build status and image
+    description: Info about each tag for given $app_id/$job_id with latest build status
+    properties:
+      desired_tag:
+        type: string
+      project_name:
+        type: string
+      build_status:
+        type: string
+      image:
+        type: string
+  AppIdJobIdTags:
+    title: Tags defined for given $app_id/$job_id
+    description: Get all the tags defined for given $app_id/$job_id along with latest build status and image
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      app_id:
+        type: string
+      job_id:
+        type: string
+      tags:
+        type: array
+        items:
+          $ref: '#/definitions/AppIdJobIdTag'
+  TargetFile:
+    title: Link to target Dockerfile
+    description: 'Link to target Dockerfile for given project, also return boolean if project has prebuild defined'
+    properties:
+      prebuild:
+        type: boolean
+      target_file_link:
+        type: string
+  ProjectBuildNameStatus:
+    title: Build name and status
+    description: Build name and status
+    properties:
+      build:
+        type: string
+      status:
+        type: string
+  ProjectWeeklyScanBuildNameStatus:
+    title: Weekly scan build name and status
+    description: Weekly scan build name and status
+    properties:
+      weeklyscan-build:
+        type: string
+      status:
+        type: string
+  ProjectBuilds:
+    properties:
+      build_number:
+        $ref: '#/definitions/ProjectBuildNameStatus'
+  ProjectWeeklyScanBuilds:
+    properties:
+      build_number:
+        $ref: '#/definitions/ProjectWeeklyScanBuildNameStatus'
+  ProjectBuildsInfo:
+    title: All the builds info for given project
+    description: All builds info for given project
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      builds:
+        $ref: '#/definitions/ProjectBuilds'
+  WeeklyScanBuildsInfo:
+    title: All the weekly scan builds info for given project
+    description: All the weekly scan builds info for given project
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      wscan-builds:
+        $ref: '#/definitions/ProjectWeeklyScanBuilds'
+  ScannerLogs:
+    title: Scanner log
+    description: All the scanner logs
+    properties:
+      logs:
+        type: string
+      description:
+        type: string
+  AllScannerLogs:
+    title: All scanner logs
+    description: All scanner logs
+    properties:
+      scanner_name:
+        $ref: '#/definitions/ScannerLogs'
+  PrebuildLintBuildScanLogs:
+    title: 'Prebuild, lint, build, scan phase logs'
+    description: 'Prebuild, Lint, build, scan phase logs'
+    properties:
+      prebuild:
+        type: string
+      lint:
+        type: string
+      build:
+        type: string
+      scan:
+        $ref: '#/definitions/AllScannerLogs'
+  BuildLogs:
+    title: 'Build info with lint, build, scan phase logs'
+    description: 'Build info with lint, build, scan phase logs'
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      build:
+        type: string
+      pre-build:
+        type: boolean
+      status:
+        type: string
+      failed-stage:
+        type: string
+      logs:
+        $ref: '#/definitions/PrebuildLintBuildScanLogs'
+  WeeklyScanLogs:
+    title: Weekly scan info with scan logs
+    description: Weekly scan info with scan logs
+    properties:
+      meta:
+        $ref: '#/definitions/Meta'
+      build:
+        type: string
+      status:
+        type: string
+      logs:
+        $ref: '#/definitions/AllScannerLogs'

--- a/ccp/apis/swagger_ccp_apis.yaml
+++ b/ccp/apis/swagger_ccp_apis.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  title: 'APIs CentOS Community Container Pipeline Service'
+  title: 'APIs for CentOS Community Container Pipeline Service'
   description: 'This document serves as API sepcification design document for CentOS Contianer Pipeline service. Purpose of APIs- Serve the project and build information - viz [names, status, logs, etc]. Consumer of APIs -  Registry UI https://registry.centos.org, This will use the APIs to show build information - viz [build names, logs, Dockerfile, etc].'
   version: 1.0.0
 host: registry.centos.org
@@ -26,141 +26,281 @@ paths:
       tags:
         - infra
       summary: Get the liveness of API service
-      description: ''
-      operationId: ccp.apis.v1.liveness
+      operationId: liveness
+      produces:
+        - application/json
       responses:
         '200':
-          description: Service is alive.
+          description: Returns service liveness status
           schema:
             $ref: '#/definitions/Status'
-  /help:
-    get:
-      tags:
-        - infra
-      summary: Get the API documentation
-      description: ''
-      operationId: ccp.apis.v1.help
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/ApiDoc'
-        '404':
-          description: Docs not found
-          schema:
-            $ref: '#/definitions/Meta'
   /namespaces:
     get:
       tags:
         - meta
       summary: Get all available namespaces accessible over APIs
-      description: ''
-      operationId: ccp.apis.v1.namespaces
+      operationId: namespaces
       produces:
         - application/json
       responses:
         '200':
-          description: OK
+          description: All the readable namespaces
           schema:
             $ref: '#/definitions/Namespaces'
-        '404':
-          description: No namespaces found
-          schema:
-            $ref: '#/definitions/Meta'
-  /$namespace/projects:
+  /namespace/{namespace}/projects:
     get:
       tags:
         - meta
-      summary: Get all the projects in given namespace.
+      summary: Get all the projects in given namespace
       description: ''
-      operationId: ccp.apis.v1.projects
+      operationId: namespace_projects
       produces:
         - application/json
+      parameters: 
+        - name: namespace
+          in: path
+          type: string
+          description: namespace to list projects from
+          required: true
       responses:
         '200':
           description: OK
           schema:
             $ref: '#/definitions/Projects'
-  /$namespace/$app-id/$job-id/$desired-tag/metadata:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tag/{desired_tag}/metadata:
     get:
       tags:
         - projects
-      summary: Get the metadata of the given project name.
-      description: Get all the metadata of project as provided in container index.
-      operationId: ccp.apis.v1.metadata
+      summary: Get the metadata of the given project
+      description: Get the metadata of project as provided in container index
+      operationId: project_metadata
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace to list projects from
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id
+          required: true
+          type: string
+        - name: desired_tag
+          in: path
+          description: desired-tag
+          required: true
+          type: string
       responses:
         '200':
-          description: OK
+          description: Build information of project as recorded in index
           schema:
             $ref: '#/definitions/ProjectMetadata'
-  /$namespace/$app_id/$job_id/desired-tags:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tags:
     get:
       tags:
         - projects
       summary: Get tags for given $app_id/$job_id with build status and image
-      description: Get all the tags defined for given $app_id/$job_id along with latest build status and image
-      operationId: ccp.apis.v1.desired_tags
+      description: Get all the tags defined for given $app_id/$job_id along with latest build status and image name
+      operationId: project_desired_tags
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace of the project
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id of the project
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id of the project
+          required: true
+          type: string
       responses:
         '200':
-          description: OK
+          description: All the desired tags for given project
           schema:
             $ref: '#/definitions/AppIdJobIdTags'
-  /$namespace/$app-id/$job-id/$desired-tag/target-file:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tag/{desired_tag}/target-file:
     get:
       tags:
         - projects
       summary: Get Dockerfile for given project
       description: Get Dockerfile for given project
-      operationId: ccp.apis.v1.target_file
+      operationId: project_target_file
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace of the project
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id of the project
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id of the project
+          required: true
+          type: string
+        - name: desired_tag
+          in: path
+          description: desired-tag of the project
+          required: true
+          type: string
       responses:
         '200':
           description: OK
           schema:
             $ref: '#/definitions/TargetFile'
-  /$namespace/$app-id/$job-id/$desired-tag/builds:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tag:
     get:
       tags:
         - builds
       summary: Get all the builds info for given project
-      description: 'Get all the builds number, name and status'
-      operationId: ccp.apis.v1.builds
+      description: Get all the builds number, name and status for given project
+      operationId: project_builds
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace of the project
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id of the project
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id of the project
+          required: true
+          type: string
+        - name: desired_tag
+          in: path
+          description: desired-tag of the project
+          required: true
+          type: string
       responses:
         '200':
-          description: OK
+          description: Al the builds for given project
           schema:
             $ref: '#/definitions/ProjectBuildsInfo'
-  /$namespace/$app-id/$job-id/$desired-tag/wscan-builds:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tag/{desired_tag}/wscan-builds:
     get:
       tags:
         - builds
       summary: Get all the weekly scan builds info for given project
       description: Get all the weekly scan builds info for given project
-      operationId: ccp.apis.v1.wscan_builds
+      operationId: project_wscan_builds
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace of the project
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id of the project
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id of the project
+          required: true
+          type: string
+        - name: desired_tag
+          in: path
+          description: desired-tag of the project
+          required: true
+          type: string
       responses:
         '200':
-          description: OK
+          description: All weekly scan builds for given project 
           schema:
             $ref: '#/definitions/WeeklyScanBuildsInfo'
-  /$namespace/$app-id/$job-id/$desired-tag/$build/build-logs:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tag/{desired_tag}/build/{build}/logs:
     get:
       tags:
         - builds
-      summary: Get the referenced build logs
-      description: Get the referenced build logs
+      summary: Build logs for given build number
+      description: Build logs for given build number of the project
+      operationId: project_build_logs
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace of the project
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id of the project
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id of the project
+          required: true
+          type: string
+        - name: desired_tag
+          in: path
+          description: desired-tag of the project
+          required: true
+          type: string
+        - name: build
+          in: path
+          description: build number
+          required: true
+          type: string
       responses:
         '200':
-          description: OK
+          description: Build logs for given build number
           schema:
             $ref: '#/definitions/BuildLogs'
-  /$namespace/$app-id/$job-id/$desired-tag/$build/wscan-logs:
+  /namespace/{namespace}/app-id/{app_id}/job-id/{job_id}/desired-tag/{desired_tag}/wscan-build/{build}/logs:
     get:
       tags:
         - builds
-      summary: Get the referenced wscan build logs
-      description: Get the referenced wscan build logs
+      summary: Weekly scan logs for given wscan-build number
+      description:  Weekly scan logs for given wscan-build number of the 
+      operationId: project_wscan_build_logs
+      parameters: 
+        - name: namespace
+          in: path
+          description: namespace of the project
+          required: true
+          type: string
+        - name: app_id
+          in: path
+          description: app-id of the project
+          required: true
+          type: string
+        - name: job_id
+          in: path
+          description: job-id of the project
+          required: true
+          type: string
+        - name: desired_tag
+          in: path
+          description: desired-tag of the project
+          required: true
+          type: string
+        - name: build
+          in: path
+          description: build number
+          required: true
+          type: string
       responses:
         '200':
-          description: OK
+          description: Weekly scan logs for given wscan-build number
           schema:
             $ref: '#/definitions/WeeklyScanLogs'
 definitions:
@@ -180,14 +320,6 @@ definitions:
         $ref: '#/definitions/Meta'
       status:
         type: string
-  ApiDoc:
-    title: API document
-    description: Api Documentation
-    properties:
-      meta:
-        $ref: '#/definitions/Meta'
-      docs:
-        type: object
   Namespaces:
     title: List of available OpenShift namespaces
     description: List of readable namespaces by API server
@@ -207,8 +339,6 @@ definitions:
       job_id:
         type: string
       desired_tag:
-        type: string
-      name:
         type: string
   Projects:
     title: List of all the projects in given namespace
@@ -256,8 +386,6 @@ definitions:
     properties:
       desired_tag:
         type: string
-      project_name:
-        type: string
       build_status:
         type: string
       image:
@@ -280,6 +408,8 @@ definitions:
     title: Link to target Dockerfile
     description: 'Link to target Dockerfile for given project, also return boolean if project has prebuild defined'
     properties:
+      meta:
+        $ref: '#/definitions/Meta'
       prebuild:
         type: boolean
       target_file_link:


### PR DESCRIPTION
This PR adds API specifications for CCCP. These APIs are readonly APIs serving details about projects, builds and all its artifacts. File `ccp/apis/swagger_ccp_apis.yaml` is added in this PR, which serves as API specifications, http://editor.swagger.io/ can be used to view the API specifications.