### PR TITLE
Remove 'docker images' added for debug purpose during PoC

### DIFF
--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -111,7 +111,6 @@ objects:
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 sh "docker build --no-cache -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
-                                sh "docker images"
                             }
                             image_is_built = true
                         }


### PR DESCRIPTION
The command was added during PoC to ensure that images are indeed getting listed. This isn't much helpful anymore. Plus it would show up as a part of build logs and expose internal registry name and list of images on the node which doesn't look like a good idea.