### PR TITLE
Adding python-requests as a prereq and to slave container.

### DIFF
--- a/Dockerfiles/ccp-openshift-slave/Dockerfile
+++ b/Dockerfiles/ccp-openshift-slave/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/openshift/jenkins-slave-base-centos7
 
-RUN yum install -y PyYAML docker mailx postfix epel-release && \
+RUN yum install -y PyYAML python-requests docker mailx postfix epel-release && \
     yum install -y npm && \
     yum clean all && \
     npm install -g dockerfile_lint

--- a/docs/install-service/setup-openshift-372.md
+++ b/docs/install-service/setup-openshift-372.md
@@ -252,6 +252,7 @@ OpenShift installation. Use the following Ansible inventory file:
             - python-rhsm-certificates
             - centos-release-openshift-origin37.noarch
             - python-ipaddress
+            - python-requests
 
       - name: Start services
         systemd: state=started enabled=yes name={{ item }}

--- a/docs/install-service/setup-openshift-390.md
+++ b/docs/install-service/setup-openshift-390.md
@@ -252,6 +252,7 @@ OpenShift installation. Use the following Ansible inventory file:
             - python-rhsm-certificates
             - centos-release-openshift-origin39.noarch
             - python-ipaddress
+            - python-requests
 
       - name: Start services
         systemd: state=started enabled=yes name={{ item }}

--- a/provision/main.yaml
+++ b/provision/main.yaml
@@ -25,6 +25,7 @@
             - python-ipaddress
             - rsync
             - PyYAML
+            - python-requests
 
       - name: Start services
         systemd: state=started enabled=yes name={{ item }}


### PR DESCRIPTION
Python-requests needs to be installed for using requests, as needed by APIClients coming soon.

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>