### PR TITLE
Remove local base image and always pull base image for building

### DIFF
--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -65,6 +65,7 @@ objects:
 
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def slave_container_name = "jnlp_ccp-pipeline-master"
+                    def base_image_name= "base/image-with:tag"
 
                     // setting this to ensure the user is notificatied only after the mandatory stages are complete
                     // i.e. (checkout, prebuild) - lint - build - scan - deliver
@@ -111,7 +112,8 @@ objects:
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 echo "Cleanup the local parent image if existing"
-                                def output = sh(returnStdout:true, script: "docker rmi `cat ${TARGET_FILE}|awk '/^FROM/ {print $2}'` > image-remove 2>&1", returnStatus: true)
+                                base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
+                                def output = sh(returnStdout:true, script: "docker rmi ${base_image_name} > image-remove 2>&1", returnStatus: true)
                                 sh "cat image-remove"
                                 echo "Build the image by always pulling the base image"
                                 sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
@@ -162,11 +164,10 @@ objects:
                         // we need to make sure the image is removed in either case
                         stage('Remove the image') {
                           // don't fail the pipeline if image removal failed due to some error
-                          // the dangling images removal should be handled seprately by some cron etc
                           sh (script: "docker rmi ${image_name_with_registry}; docker rmi ${image_name}", returnStatus: true)
-                          def output = sh(returnStdout:true, script: "docker rmi `cat ${TARGET_FILE}|awk '/^FROM/ {print $2}'` > image-remove 2>&1", returnStatus: true)
+                          def output = sh(returnStdout:true, script: "docker rmi ${base_image_name} > image-remove 2>&1", returnStatus: true)
                           sh "cat image-remove"
-                          sh(script: "docker rmi `docker images -q -f dangling=true`")
+                          sh(script: "docker rmi `docker images -q -f dangling=true`", returnStatus: true)
                         }
                       }
                   }

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -111,7 +111,7 @@ objects:
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 echo "Cleanup the local parent image if existing"
-                                def output = sh(returnStdout:true, script: "docker rmi $(cat ${TARGET_FILE}|awk '/^FROM/ {print $2}') > image-remove 2>&1", returnStatus: true)
+                                def output = sh(returnStdout:true, script: "docker rmi `cat ${TARGET_FILE}|awk '/^FROM/ {print $2}'` > image-remove 2>&1", returnStatus: true)
                                 sh "cat image-remove"
                                 echo "Build the image by always pulling the base image"
                                 sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
@@ -164,6 +164,9 @@ objects:
                           // don't fail the pipeline if image removal failed due to some error
                           // the dangling images removal should be handled seprately by some cron etc
                           sh (script: "docker rmi ${image_name_with_registry}; docker rmi ${image_name}", returnStatus: true)
+                          def output = sh(returnStdout:true, script: "docker rmi `cat ${TARGET_FILE}|awk '/^FROM/ {print $2}'` > image-remove 2>&1", returnStatus: true)
+                          sh "cat image-remove"
+                          sh(script: "docker rmi `docker images -q -f dangling=true`")
                         }
                       }
                   }

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -65,7 +65,10 @@ objects:
 
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def slave_container_name = "jnlp_ccp-pipeline-master"
-                    def base_image_name= "base/image-with:tag"
+
+                    //base image name is retrieved from the target-file of the source repo
+                    //this is the FROM in the target-file. for example 'base/image-with:tag'
+                    def base_image_name = ""
 
                     // setting this to ensure the user is notificatied only after the mandatory stages are complete
                     // i.e. (checkout, prebuild) - lint - build - scan - deliver
@@ -111,11 +114,8 @@ objects:
                         }
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
-                                echo "Cleanup the local parent image if existing"
                                 base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
-                                def output = sh(returnStdout:true, script: "docker rmi ${base_image_name} > image-remove 2>&1", returnStatus: true)
-                                sh "cat image-remove"
-                                echo "Build the image by always pulling the base image"
+                                // Build the image by always pulling the base image
                                 sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
                             }
                             image_is_built = true

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -110,7 +110,11 @@ objects:
                         }
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
-                                sh "docker build --no-cache -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
+                                echo "Cleanup the local parent image if existing"
+                                def output = sh(returnStdout:true, script: "docker rmi $(cat ${TARGET_FILE}|grep '^FROM'|awk '{print $2}') > image-remove 2>&1", returnStatus: true)
+                                sh "cat image-remove"
+                                echo "Build the image by always pulling the base image"
+                                sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
                             }
                             image_is_built = true
                         }

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -111,7 +111,7 @@ objects:
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 echo "Cleanup the local parent image if existing"
-                                def output = sh(returnStdout:true, script: "docker rmi $(cat ${TARGET_FILE}|grep '^FROM'|awk '{print $2}') > image-remove 2>&1", returnStatus: true)
+                                def output = sh(returnStdout:true, script: "docker rmi $(cat ${TARGET_FILE}|awk '/^FROM/ {print $2}') > image-remove 2>&1", returnStatus: true)
                                 sh "cat image-remove"
                                 echo "Build the image by always pulling the base image"
                                 sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"


### PR DESCRIPTION
Base image is not getting pulled always, so sometimes the dependency image is not getting proper/recently built base image.
This PR makes sure:
* base image is removed from the node before trying to build from it
* force pull the base image for building the image, so that image is always built on top of the recently built base image.
