### PR TITLE
Fixes weekly scan processing for library images

### DIFF
--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -42,9 +42,16 @@ objects:
             )
             {
                 node('ccp-pipeline-weekly') {
-                    def image_name = "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
-                    def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
-                    def image_tags = "http://${REGISTRY_URL}/v2/${APP_ID}/${JOB_ID}/tags/list"
+                    if (${APP_ID} == "library"){
+                      def image_name = "${JOB_ID}:${DESIRED_TAG}"
+                      def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
+                      def image_tags = "http://${REGISTRY_URL}/v2/${JOB_ID}/tags/list"
+
+                    } else {
+                      def image_name = "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
+                      def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
+                      def image_tags = "http://${REGISTRY_URL}/v2/${APP_ID}/${JOB_ID}/tags/list"
+                    }
                     def slave_container_name = "jnlp_ccp-pipeline-weekly"
                     def image_in_registry = false
                     // setting this to ensure the user is notified correctly if the required stages in weekly scan are complete


### PR DESCRIPTION
 Fixes: https://openshift.io/bkundu@redhat.com/CentOS_Container_Pipeline/plan/detail/1587

 The library images lands in registry as r.c.o/centos:latest, however app_id=library is defined for same in index.
 This changeset identifies respective images and defines proper image_name and tags URL.