### PR TITLE
Removes references to openshift branch from CI

### DIFF
--- a/ci/jjb_service_job.yml
+++ b/ci/jjb_service_job.yml
@@ -1,5 +1,5 @@
 - job:
-    name: 'centos-container-pipeline-service-job-openshift'
+    name: 'centos-container-pipeline-service-job'
     description: |
         This job is a service job for managing all the CI jobs from container-pipeline-service https://github.com/centos/container-pipeline-service
 
@@ -20,7 +20,7 @@
             url: https://github.com/CentOS/container-pipeline-service.git
             skip-tag: True
             branches:
-                - openshift
+                - master
     builders:
         - shell: |
             jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini update ci/job.yml

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -110,13 +110,8 @@
             echo ${GIT_URL}
             echo ${GIT_BRANCH}
             CI_DEBUG=0
-            if [ ${ghprbTargetBranch} == "openshift" ]
-            then
-              git rebase origin/${ghprbTargetBranch}
-              sh ci/ccp_ci_functional.sh ${GIT_URL} ${GIT_BRANCH} ${sha1} ${CI_DEBUG}
-            else
-              echo "PR's target branch is not openshift."
-            fi
+            git rebase origin/${ghprbTargetBranch}
+            sh ci/ccp_ci_functional.sh ${GIT_URL} ${GIT_BRANCH} ${sha1} ${CI_DEBUG}
 
 
 - job:
@@ -173,13 +168,8 @@
             echo ${GIT_URL}
             echo ${GIT_BRANCH}
             CI_DEBUG=1
-            if [ ${ghprbTargetBranch} == "openshift" ]
-            then
-              git rebase origin/${ghprbTargetBranch}
-              sh ci/ccp_ci_functional.sh ${GIT_URL} ${GIT_BRANCH} ${sha1} ${CI_DEBUG}
-            else
-              echo "PRs target branch is not openshift."
-            fi
+            git rebase origin/${ghprbTargetBranch}
+            sh ci/ccp_ci_functional.sh ${GIT_URL} ${GIT_BRANCH} ${sha1} ${CI_DEBUG}
 
 
 - job:
@@ -237,13 +227,8 @@
             echo ${GIT_URL}
             echo ${GIT_BRANCH}
             CI_DEBUG=0
-            if [ ${ghprbTargetBranch} == "openshift" ]
-            then
-              git rebase origin/${ghprbTargetBranch}
-              bash ci/ccp_ci_unittests.sh ${CI_DEBUG}
-            else
-              echo "PR's target branch is not openshift."
-            fi
+            git rebase origin/${ghprbTargetBranch}
+            bash ci/ccp_ci_unittests.sh ${CI_DEBUG}
 
 - job:
     name: 'centos-container-pipeline-service-ci-pr-unittests-debug'
@@ -299,10 +284,5 @@
             echo ${GIT_URL}
             echo ${GIT_BRANCH}
             CI_DEBUG=1
-            if [ ${ghprbTargetBranch} == "openshift" ]
-            then
-              git rebase origin/${ghprbTargetBranch}
-              bash ci/ccp_ci_unittests.sh ${CI_DEBUG}
-            else
-              echo "PR's target branch is not openshift."
-            fi
+            git rebase origin/${ghprbTargetBranch}
+            bash ci/ccp_ci_unittests.sh ${CI_DEBUG}


### PR DESCRIPTION
This PR removes reference to openshift branch from the CI and replaces them with master or doesn't do anything where master is assumed as the default.