### PR TITLE
Build container images using buildah instead of docker build

### DIFF
--- a/Dockerfiles/ccp-openshift-slave/Dockerfile
+++ b/Dockerfiles/ccp-openshift-slave/Dockerfile
@@ -15,4 +15,4 @@ ENV BASH_ENV=/opt/rh/go-toolset-7/enable \
     PROMPT_COMMAND=". /opt/rh/go-toolset-7/enable"
 
 ADD ./ /opt/ccp-openshift/
-VOLUME ["/opt/ccp-openshift/ccp/scanning"]
+VOLUME ["/opt/ccp-openshift/ccp/scanning", "/var/lib/containers"]

--- a/Dockerfiles/ccp-openshift-slave/Dockerfile
+++ b/Dockerfiles/ccp-openshift-slave/Dockerfile
@@ -1,9 +1,18 @@
 FROM registry.centos.org/openshift/jenkins-slave-base-centos7
 
-RUN yum install -y PyYAML python-requests docker mailx postfix epel-release && \
+ADD build_buildah.sh /tmp
+
+RUN yum update -y && \
+    yum install -y PyYAML python-requests docker mailx postfix epel-release && \
     yum install -y npm && \
     yum clean all && \
-    npm install -g dockerfile_lint
+    npm install -g dockerfile_lint && \
+    sh /tmp/build_buildah.sh && \
+    rm -rf /tmp/build_buildah.sh /tmp/buildah
+
+ENV BASH_ENV=/opt/rh/go-toolset-7/enable \
+    ENV=/opt/rh/go-toolset-7/enable \
+    PROMPT_COMMAND=". /opt/rh/go-toolset-7/enable"
 
 ADD ./ /opt/ccp-openshift/
 VOLUME ["/opt/ccp-openshift/ccp/scanning"]

--- a/Dockerfiles/ccp-openshift-slave/Dockerfile
+++ b/Dockerfiles/ccp-openshift-slave/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/openshift/jenkins-slave-base-centos7
 
-ADD build_buildah.sh /tmp
+ADD Dockerfiles/ccp-openshift-slave/build_buildah.sh /tmp
 
 RUN yum update -y && \
     yum install -y PyYAML python-requests docker mailx postfix epel-release && \

--- a/Dockerfiles/ccp-openshift-slave/build_buildah.sh
+++ b/Dockerfiles/ccp-openshift-slave/build_buildah.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+yum install -y make \
+    go-toolset-7 \
+    device-mapper-devel \
+    glib2-devel gpgme-devel \
+    libassuan-devel \
+    libseccomp-devel \
+    ostree-devel \
+    openssl-devel \
+    runc \
+    skopeo-containers
+yum clean all
+
+source /opt/rh/go-toolset-7/enable
+go get github.com/cpuguy83/go-md2man
+cp ~/go/bin/go-md2man /usr/local/bin/
+mkdir /tmp/buildah && cd /tmp/buildah
+export GOPATH=`pwd`
+git clone https://github.com/containers/buildah ./src/github.com/containers/buildah
+cd ./src/github.com/containers/buildah
+make
+make install
+cp buildah /usr/local/bin/

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -169,7 +169,7 @@ objects:
                         // we need to make sure the image is removed in either case
                         stage('Remove the image') {
                           // don't fail the pipeline if image removal failed due to some error
-                          sh (script: "docker rmi ${image_name_with_registry}; docker rmi ${image_name_with_registry}", returnStatus: true)
+                          sh (script: "buildah rmi ${image_name_with_registry}; buildah rmi ${image_name_with_registry}", returnStatus: true)
                           def output = sh(returnStdout:true, script: "docker rmi ${base_image_name} > image-remove 2>&1", returnStatus: true)
                           sh "cat image-remove"
                           sh(script: "docker rmi `docker images -q -f dangling=true`", returnStatus: true)

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -116,11 +116,12 @@ objects:
                                 sh "cat result"
                             }
                         }
-                        stage('Build the container image') {
+                        stage('Build the container image and push to Docker daemon') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
                                 // Build the image by always pulling the base image
                                 sh "buildah bud --no-cache --pull -t ${image_name_with_registry} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
+                                sh "buildah push ${image_name_with_registry} docker-daemon:${image_name_with_registry}"
                             }
                             image_is_built = true
                         }

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -47,6 +47,10 @@ objects:
                 ],
                 volumes: [
                   hostPathVolume(
+                    hostPath: '/tmp/containers',
+                    mountPath: '/var/lib/containers'
+                  ),
+                  hostPathVolume(
                     hostPath: '/var/run/docker.sock',
                     mountPath: '/var/run/docker.sock'
                   )
@@ -116,7 +120,7 @@ objects:
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
                                 // Build the image by always pulling the base image
-                                sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
+                                sh "buildah bud --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
                             }
                             image_is_built = true
                         }
@@ -142,8 +146,8 @@ objects:
                             )
                         }
                         stage("Push image to registry") {
-                            sh "docker tag ${image_name} ${image_name_with_registry}"
-                            sh "docker push ${image_name_with_registry}"
+                            sh "buildah tag ${image_name} ${image_name_with_registry}"
+                            sh "buildah push ${image_name_with_registry}"
                             // image lint - build - scan - deliver is successful
                             success = true
                         }

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -47,7 +47,7 @@ objects:
                 ],
                 volumes: [
                   hostPathVolume(
-                    hostPath: '/tmp/containers',
+                    hostPath: '/var/lib/containers',
                     mountPath: '/var/lib/containers'
                   ),
                   hostPathVolume(

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -120,33 +120,33 @@ objects:
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
                                 // Build the image by always pulling the base image
-                                sh "buildah bud --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
+                                sh "buildah bud --no-cache --pull -t ${image_name_with_registry} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
                             }
                             image_is_built = true
                         }
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/yumupdates.py > yum-check-update 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/ccp-openshift/ccp/scanning/yumupdates.py > yum-check-update 2>&1")
                                   sh "cat yum-check-update"
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/rpmverify.py > rpm-verify 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/ccp-openshift/ccp/scanning/rpmverify.py > rpm-verify 2>&1")
                                   sh "cat rpm-verify"
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/ccp-openshift/ccp/scanning/misc_package_updates.py all > misc-updates 2>&1")
                                   sh "cat misc-updates"
                                 },
                                 "Container capabilities": {
-                                  def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                  def run_label = sh (script: "docker inspect ${image_name_with_registry} --format '{{ index .Config.Labels \"RUN\" }}'")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name_with_registry} /opt/ccp-openshift/ccp/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
                                   sh "cat capabilities"
                                 }
                             )
                         }
                         stage("Push image to registry") {
-                            sh "buildah tag ${image_name} ${image_name_with_registry}"
+                            // sh "buildah tag ${image_name} ${image_name_with_registry}"
                             sh "buildah push ${image_name_with_registry}"
                             // image lint - build - scan - deliver is successful
                             success = true
@@ -168,7 +168,7 @@ objects:
                         // we need to make sure the image is removed in either case
                         stage('Remove the image') {
                           // don't fail the pipeline if image removal failed due to some error
-                          sh (script: "docker rmi ${image_name_with_registry}; docker rmi ${image_name}", returnStatus: true)
+                          sh (script: "docker rmi ${image_name_with_registry}; docker rmi ${image_name_with_registry}", returnStatus: true)
                           def output = sh(returnStdout:true, script: "docker rmi ${base_image_name} > image-remove 2>&1", returnStatus: true)
                           sh "cat image-remove"
                           sh(script: "docker rmi `docker images -q -f dangling=true`", returnStatus: true)

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -148,7 +148,7 @@ objects:
                         }
                         stage("Push image to registry") {
                             // sh "buildah tag ${image_name} ${image_name_with_registry}"
-                            sh "buildah push ${image_name_with_registry}"
+                            sh "buildah push --tls-verify=false ${image_name_with_registry}"
                             // image lint - build - scan - deliver is successful
                             success = true
                         }


### PR DESCRIPTION
This PR aims to build container images in CentOS Container Pipeline service using the `buildah` tool instead of using `docker build`. 