### PR TITLE
Push images to external registry

### DIFF
--- a/docs/install-service/setup-openshift-390.md
+++ b/docs/install-service/setup-openshift-390.md
@@ -504,3 +504,38 @@ Now, we need the Jenkins token to be made available. To do this, do the followin
 $ oc get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' # Name will be something like jenkins-token-blah
 $ oc process -p JENKINS_SECRET_NAME=jenkins-token-blah -f weekly-scan/scheduler.yaml | oc apply -f -
 ```
+
+### Push to external registry
+
+Besides pushing to the registry provisioned in private infrastructure, the
+service can also push to an external registry (like quay.io). This is an
+optional feature and service will work just fine if you don't set this up.
+However, if you would like to set this up, you need to do a bit of
+configuration.
+
+An OpenShift secret like below needs to be created and fed to `oc create`
+command:
+
+```bash
+$ cat secret.yml 
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-registry
+type: Opaque 
+stringData:
+  username: user
+  password: password
+  registry: quay.io
+```
+
+Password should be the encrypted password as generated from the account
+settings on quay.io. 
+
+With that, create the secret using:
+
+```bash
+$ oc create -f secret.yml
+```
+
+Now, trigger a build and see if it managed to push to the external registry.

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -167,6 +167,8 @@ objects:
                                 def external_registry_image_name = "${registry}/${username}/${APP_ID}-${JOB_ID}:${DESIRED_TAG}"
                                 sh(script: "docker tag ${image_name_with_registry} ${external_registry_image_name}")
                                 sh(script: "docker push ${external_registry_image_name}")
+                                echo "Remove the image after pushing to external registry"
+                                sh (script: "docker rmi ${external_registry_image_name}")
                             }
                         }
 

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -147,6 +147,28 @@ objects:
                             // image lint - build - scan - deliver is successful
                             success = true
                         }
+                        stage("Push image to external registry"){
+                            /*
+                            This is an optional stage. We will tag an image with external registry if and only if a secret named "external-registry" is found.
+                            If not, we do nothing in this stage
+                            */
+                            def EXTERNAL_REGISTRY_PUSH = sh (
+                                script: "oc get secret/external-registry",
+                                returnStdout: true,
+                                returnStatus: true
+                            )
+                            if (EXTERNAL_REGISTRY_PUSH == 0) {
+                                def username = sh(script: "oc get secret/external-registry -o yaml | grep 'username'| cut -d' ' -f4 | base64 -d", returnStdout: true)
+                                def password = sh(script: "oc get secret/external-registry -o yaml | grep 'password'| cut -d' ' -f4 | base64 -d", returnStdout: true)
+                                def registry = sh(script: "oc get secret/external-registry -o yaml | grep 'registry:'| cut -d' ' -f4 | base64 -d", returnStdout: true)
+                                echo "Login into external registry"
+                                sh (script: "export DOCKER_USERNAME=${username} && export DOCKER_PASSWORD=${password} && docker login -u \$DOCKER_USERNAME -p \$DOCKER_PASSWORD ${registry}", returnStdout: true)
+                                echo "Tagging image to push to external registry"
+                                def external_registry_image_name = "${registry}/${username}/${APP_ID}-${JOB_ID}:${DESIRED_TAG}"
+                                sh(script: "docker tag ${image_name_with_registry} ${external_registry_image_name}")
+                                sh(script: "docker push ${external_registry_image_name}")
+                            }
+                        }
 
                     }
                     finally {


### PR DESCRIPTION
This PR adds code and documentation to help push images created by the service to an external registry like quay.io. 