### PR TITLE
Node selector for pods with single job per node

### DIFF
--- a/api-server/api-server.yml
+++ b/api-server/api-server.yml
@@ -21,8 +21,8 @@ objects:
       to:
         kind: "Service"
         name: "cccp-apis"
-  - apiVersion: "v1"
-    kind: "DeploymentConfig"
+  - apiVersion: "apps/v1"
+    kind: "Deployment"
     metadata:
       name: "cccp-apis"
       annotations:
@@ -41,6 +41,8 @@ objects:
           labels:
             name: "cccp-apis"
         spec:
+          nodeSelector:
+            node-role.kubernetes.io/size: large
           containers:
           - name: "cccp-apis"
             image: "${API_SERVER_IMAGE}"
@@ -126,7 +128,7 @@ parameters:
   displayName: Git branch of the index
   description: Git branch of the index repository
 - name: MEMORY_LIMT
-  value: 512Mi
+  value: 2Gi
   required: true
   displayName: Memory limit of api-server pod
   description: Memory to be given to each api-server pod

--- a/ci/ccp_ci_functional.sh
+++ b/ci/ccp_ci_functional.sh
@@ -113,10 +113,10 @@ echo "Prepare ansible inventory for service setup"
 ssh $sshoptserr $ansible_node sed -i "s/nfs_serv/$nfs_node/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_1/$openshift_1_node/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_2/$openshift_2_node/g" /opt/ccp-openshift/provision/hosts.ci
-ssh $sshoptserr $ansible_node sed -i "s/openshift_2/$openshift_3_node/g" /opt/ccp-openshift/provision/hosts.ci
+ssh $sshoptserr $ansible_node sed -i "s/openshift_3/$openshift_3_node/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_1/$openshift_1_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_2/$openshift_2_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
-ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_2/$openshift_3_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
+ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_3/$openshift_3_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/cluster_subnet_ip/$cluster_subnet_ip/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/oc_username/cccp/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/oc_passwd/developer/g" /opt/ccp-openshift/provision/hosts.ci

--- a/ci/ccp_ci_functional.sh
+++ b/ci/ccp_ci_functional.sh
@@ -25,7 +25,7 @@ rtn_code=0
 DEBUG_PERIOD=7200
 
 echo "Get nodes from duffy pool"
-IFS=' ' read -ra node_details <<< $(cico node get --count 4 -f value -c hostname -c ip_address -c comment)
+IFS=' ' read -ra node_details <<< $(cico node get --count 5 -f value -c hostname -c ip_address -c comment)
 ansible_node_host=${node_details[0]}.ci.centos.org
 ansible_node=${node_details[1]}
 nfs_node=${node_details[3]}.ci.centos.org
@@ -34,7 +34,9 @@ openshift_1_node=${node_details[6]}.ci.centos.org
 openshift_1_node_ip=${node_details[7]}
 openshift_2_node=${node_details[9]}.ci.cento.org
 openshift_2_node_ip=${node_details[10]}
-cico_node_key=${node_details[11]}
+openshift_3_node=${node_details[12]}.ci.centos.org
+openshift_3_node_ip=${node_details[13]}
+cico_node_key=${node_details[14]}
 cluster_subnet_ip="172.19.2.0"
 
 if [ ${#cico_node_key} -le 3 ]
@@ -52,6 +54,8 @@ echo "Openshift Node 1: $openshift_1_node"
 echo "Openshift Node 1 IP: $openshift_1_node_ip"
 echo "Openshift Node 2: $openshift_2_node"
 echo "Openshift Node 2 IP: $openshift_2_node_ip"
+echo "Openshift Node 3: $openshift_3_node"
+echo "Openshift Node 3 IP: $openshift_3_node_ip"
 echo "Node hash: $cico_node_key"
 echo "Cluster subnet: $cluster_subnet_ip"
 echo "=============================================================\n\n"
@@ -73,6 +77,7 @@ export sshoptserr="-tt -o LogLevel=error -o UserKnownHostsFile=/dev/null -o Stri
 echo "Create etc hosts in ansible node"
 ssh $sshopts $ansible_node "echo \"$openshift_1_node_ip $openshift_1_node\" >> /etc/hosts"
 ssh $sshopts $ansible_node "echo \"$openshift_2_node_ip $openshift_2_node\" >> /etc/hosts"
+ssh $sshopts $ansible_node "echo \"$openshift_3_node_ip $openshift_3_node\" >> /etc/hosts"
 ssh $sshopts $ansible_node "echo \"$nfs_node_ip $nfs_node\" >> /etc/hosts"
 
 echo "Add ssh keys to all the nodes"
@@ -81,13 +86,13 @@ ssh $sshopts $ansible_node 'rm -rf ~/.ssh/id_rsa* && ssh-keygen -t rsa -N "" -f 
 public_key=$(ssh $sshopts $ansible_node 'cat ~/.ssh/id_rsa.pub')
 
 # Add public key to all the ci nodes
-for node in {$nfs_node_ip,$openshift_1_node_ip,$openshift_2_node_ip}
+for node in {$nfs_node_ip,$openshift_1_node_ip,$openshift_2_node_ip,$openshift_3_node_ip}
 do
     ssh $sshopts $node "echo \"$public_key\" >> ~/.ssh/authorized_keys"
 done
 
 echo "Add ssh fringer prints for all node to ansible controller"
-for node in {$nfs_node,$openshift_1_node,$openshift_2_node}
+for node in {$nfs_node,$openshift_1_node,$openshift_2_node,$openshift_3_node}
 do
     ssh $sshopts $ansible_node "ssh-keyscan -t rsa,dsa $node 2>/dev/null >> ~/.ssh/known_hosts"
 done
@@ -108,8 +113,10 @@ echo "Prepare ansible inventory for service setup"
 ssh $sshoptserr $ansible_node sed -i "s/nfs_serv/$nfs_node/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_1/$openshift_1_node/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_2/$openshift_2_node/g" /opt/ccp-openshift/provision/hosts.ci
+ssh $sshoptserr $ansible_node sed -i "s/openshift_2/$openshift_3_node/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_1/$openshift_1_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_2/$openshift_2_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
+ssh $sshoptserr $ansible_node sed -i "s/openshift_ip_2/$openshift_3_node_ip/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/cluster_subnet_ip/$cluster_subnet_ip/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/oc_username/cccp/g" /opt/ccp-openshift/provision/hosts.ci
 ssh $sshoptserr $ansible_node sed -i "s/oc_passwd/developer/g" /opt/ccp-openshift/provision/hosts.ci

--- a/provision/hosts.ci
+++ b/provision/hosts.ci
@@ -10,7 +10,7 @@ nfs_registry
 # SSH user, this user should allow ssh based auth without requiring a password
 ansible_ssh_user=root
 
-openshift_node_groups=[{'name': 'ccp-openshift-master', 'labels': ['node-role.kubernetes.io/master=true', 'node-role.kubernetes.io/node-type=metrics', 'node-role.kubernetes.io/infra=true', 'node-role.kubernetes.io/size=large'], 'edits': []}, {'name': 'ccp-openshift-node', 'labels': ['node-role.kubernetes.io/zone=default'], 'edits': []}, {'name': 'ccp-openshift-large-node', 'labels': ['node-role.kubernetes.io/zone=default', 'node-role.kubernetes.io/size=large']}]
+openshift_node_groups=[{'name': 'ccp-openshift-master', 'labels': ['node-role.kubernetes.io/master=true', 'node-role.kubernetes.io/node-type=metrics', 'node-role.kubernetes.io/infra=true', 'node-role.kubernetes.io/size=master-large'], 'edits': []}, {'name': 'ccp-openshift-node', 'labels': ['node-role.kubernetes.io/zone=default', 'node-role.kubernetes.io/size=small'], 'edits': []}, {'name': 'ccp-openshift-large-node', 'labels': ['node-role.kubernetes.io/zone=default', 'node-role.kubernetes.io/size=large']}]
 
 # If ansible_ssh_user is not root, ansible_become must be set to true
 debug_level=4
@@ -59,6 +59,7 @@ openshift_1
 [nodes]
 openshift_1 openshift_node_group_name='ccp-openshift-master' openshift_schedulable=true openshift_ip=openshift_ip_1
 openshift_2 openshift_node_group_name='ccp-openshift-large-node' openshift_schedulable=true openshift_ip=openshift_ip_2
+openshift_3 openshift_node_group_name='ccp-openshift-node' openshift_schedulable=true openshift_ip=openshift_ip_3
 
 [nfs_registry]
 nfs_serv

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -24,27 +24,55 @@ objects:
                 ])
             ])
             podTemplate(
-                cloud: 'openshift',
-                name: 'ccp-pipeline-seed',
-                label: 'ccp-pipeline-seed',
-                namespace: '${NAMESPACE}',
-                serviceAccount: 'jenkins',
-                containers: [
-                  containerTemplate(
-                    name: 'jnlp',
-                    image: '${CCP_OPENSHIFT_SLAVE_IMAGE}',
-                    ttyEnabled: true,
-                    alwaysPullImage: true,
-                    workingDir: '/tmp',
-                    privileged: true,
-                    args: '${computer.jnlpmac} ${computer.name}',
-                    resourceRequestCpu: '${SEED_JOB_CPU}',
-                    resourceRequestMemory: '${SEED_JOB_MEMORY}'
-                  )
-                ],
+            cloud: 'openshift',
+            yaml: """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+                name: ccp-pipeline-seed
+                labels:
+                    ccp-pipeline-build-pod-type: seed
+            spec:
+                serviceAccount: jenkins
+                namespace: ${NAMESPACE}
+                affinity:
+                    nodeAffinity:
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                            nodeSelectorTerms:
+                                - matchExpressions:
+                                    - key: node-role.kubernetes.io/size
+                                      operator: In
+                                      values:
+                                          - large
+                    podAntiAffinity:
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                            - topologyKey: kubernetes.io/hostname
+                              namespace: ${NAMESPACE}
+                              labelSelector:
+                                  matchExpressions:
+                                        - key: ccp-pipeline-build-pod-type
+                                          operator: In
+                                          values:
+                                              - seed
+                                              - master
+                containers:
+                  - name: jnlp
+                    image: ${CCP_OPENSHIFT_SLAVE_IMAGE}
+                    tty: true
+                    imagePullPolicy: Always
+                    workingDir: /tmp
+                    privileged: true
+                    resources:
+                        requests:
+                            cpu: ${SEED_JOB_CPU}
+                            memory: ${SEED_JOB_MEMORY}
+                        limits:
+                            cpu: ${SEED_JOB_CPU}
+                            memory: ${SEED_JOB_MEMORY}
+              """
             )
             {
-                node ('ccp-pipeline-seed'){
+                node (POD_LABEL){
                     stage('Checkout Sources') {
                         dir("${CONTAINER_INDEX_DIR}") {
                             git url: '${CONTAINER_INDEX_REPO}', branch: '${CONTAINER_INDEX_BRANCH}'

--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -54,7 +54,7 @@ objects:
                                           operator: In
                                           values:
                                               - seed
-                                              - master
+                                              - weekly-trigger
                 containers:
                   - name: jnlp
                     image: ${CCP_OPENSHIFT_SLAVE_IMAGE}

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -93,7 +93,7 @@ objects:
                     }
 
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
-                    def slave_container_name = POD_LABEL
+                    def slave_container_name = "${APP_ID}-${JOB_ID}-${DESIRED_TAG}-${BUILD_NUMBER}"
                     def slave_container_id = ""
 
                     //base image name is retrieved from the target-file of the source repo
@@ -123,7 +123,7 @@ objects:
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
                                 //Get the image details for future use
                                 base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
-                                slave_container_name = sh(returnStdout:true, script:  "echo ${POD_LABEL} | sed 's/_/-/g'").trim()
+                                slave_container_name = sh(returnStdout:true, script:  "echo ${slave_container_name} | sed 's/_/-/g'").trim()
                                 echo "slave container name: ${slave_container_name}"
                                 slave_container_id = sh(returnStdout:true, script: "docker ps -qf name=${slave_container_name} | head -n 1").trim()
                                 echo "Slave container id: ${slave_container_id}"

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -93,7 +93,8 @@ objects:
                     }
 
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
-                    def slave_container_name = "jnlp_ccp-pipeline-master"
+                    def slave_container_name = POD_LABEL
+                    def slave_container_id = ""
 
                     //base image name is retrieved from the target-file of the source repo
                     //this is the FROM in the target-file. for example 'base/image-with:tag'
@@ -119,6 +120,14 @@ objects:
                                     [url: "${GIT_URL}"]
                                 ]
                             ])
+                            dir("${PIPELINE_NAME}/${GIT_PATH}"){
+                                //Get the image details for future use
+                                base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
+                                slave_container_name = sh(returnStdout:true, script:  "echo ${POD_LABEL} | sed 's/_/-/g'").trim()
+                                echo "slave container name: ${slave_container_name}"
+                                slave_container_id = sh(returnStdout:true, script: "docker ps -qf name=${slave_container_name} | head -n 1").trim()
+                                echo "Slave container id: ${slave_container_id}"
+                            }
                         }
                         stage('Prebuild source repo'){
                             if("${PRE_BUILD_SCRIPT}" != "None")
@@ -143,7 +152,6 @@ objects:
                         }
                         stage('Build the container image') {
                             dir("${PIPELINE_NAME}/${GIT_PATH}"){
-                                base_image_name = sh(returnStdout:true, script: "cat ${TARGET_FILE}|awk '/^FROM/ {print \$2}'").trim()
                                 // Build the image by always pulling the base image
                                 sh "docker build --no-cache --pull -t ${image_name} -f ${TARGET_FILE} ${BUILD_CONTEXT}"
                             }
@@ -152,20 +160,20 @@ objects:
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/yumupdates.py > yum-check-update 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/yumupdates.py > yum-check-update 2>&1")
                                   sh "cat yum-check-update"
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/rpmverify.py > rpm-verify 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/rpmverify.py > rpm-verify 2>&1")
                                   sh "cat rpm-verify"
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/misc_package_updates.py all > misc-updates 2>&1")
                                   sh "cat misc-updates"
                                 },
                                 "Container capabilities": {
                                   def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                  sh (returnStdout: true, script: "docker run --user root --rm --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
                                   sh "cat capabilities"
                                 }
                             )

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -56,8 +56,8 @@ objects:
                                             - key: ccp-pipeline-build-pod-type
                                               operator: In
                                               values:
-                                                  - seed
                                                   - master
+                                                  - weekly-scan
                     containers:
                       - name: jnlp
                         image: ${CCP_OPENSHIFT_SLAVE_IMAGE}

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -29,9 +29,27 @@ objects:
             podTemplate(
                 cloud: 'openshift',
                 name: 'ccp-pipeline-master',
-                label: 'ccp-pipeline-master',
+                labels: [
+                    ccp-pipeline-build-pod-type: master-job
+                ],
                 namespace: '${NAMESPACE}',
                 serviceAccount: 'jenkins',
+                affinity(
+                    podAntiAffinity(
+                        requiredDuringSchedulingIgnoredDuringExecution:[
+                            labelSelector:(
+                                matchExpressions:([
+                                    key: 'ccp-pipeline-build-pod-type',
+                                    operator: 'In',
+                                    values: [
+                                        'seed-job',
+                                        'master-job'
+                                    ]
+                                ])
+                            )
+                        ],
+                    )
+                )
                 containers: [
                   containerTemplate(
                     name: 'jnlp',

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -28,50 +28,61 @@ objects:
             ])
             podTemplate(
                 cloud: 'openshift',
-                name: 'ccp-pipeline-master',
-                labels: [
-                    ccp-pipeline-build-pod-type: master-job
-                ],
-                namespace: '${NAMESPACE}',
-                serviceAccount: 'jenkins',
-                affinity(
-                    podAntiAffinity(
-                        requiredDuringSchedulingIgnoredDuringExecution:[
-                            labelSelector:(
-                                matchExpressions:([
-                                    key: 'ccp-pipeline-build-pod-type',
-                                    operator: 'In',
-                                    values: [
-                                        'seed-job',
-                                        'master-job'
-                                    ]
-                                ])
-                            )
-                        ],
-                    )
-                )
-                containers: [
-                  containerTemplate(
-                    name: 'jnlp',
-                    image: '${CCP_OPENSHIFT_SLAVE_IMAGE}',
-                    ttyEnabled: true,
-                    alwaysPullImage: true,
-                    workingDir: '/tmp',
-                    privileged: true,
-                    args: '${computer.jnlpmac} ${computer.name}',
-                    resourceRequestCpu: '${MASTER_JOB_CPU}',
-                    resourceRequestMemory: '${MASTER_JOB_MEMORY}'
-                  )
-                ],
-                volumes: [
-                  hostPathVolume(
-                    hostPath: '/var/run/docker.sock',
-                    mountPath: '/var/run/docker.sock'
-                  )
-                ]
+                yaml: """
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                    name: ccp-pipeline-master
+                    labels:
+                        ccp-pipeline-build-pod-type: master
+                spec:
+                    serviceAccount: jenkins
+                    namespace: ${NAMESPACE}
+                    affinity:
+                        nodeAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                                nodeSelectorTerms:
+                                    - matchExpressions:
+                                        - key: node-role.kubernetes.io/size
+                                          operator: In
+                                          values:
+                                              - small
+                        podAntiAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                                - topologyKey: kubernetes.io/hostname
+                                  namespace: ${NAMESPACE}
+                                  labelSelector:
+                                      matchExpressions:
+                                            - key: ccp-pipeline-build-pod-type
+                                              operator: In
+                                              values:
+                                                  - seed
+                                                  - master
+                    containers:
+                      - name: jnlp
+                        image: ${CCP_OPENSHIFT_SLAVE_IMAGE}
+                        tty: true
+                        imagePullPolicy: Always
+                        workingDir: /tmp
+                        privileged: true
+                        resources:
+                            requests:
+                                cpu: ${MASTER_JOB_CPU}
+                                memory: ${MASTER_JOB_MEMORY}
+                            limits:
+                                cpu: ${MASTER_JOB_CPU}
+                                memory: ${MASTER_JOB_MEMORY}
+                        volumeMounts:
+                            - mountPath: /var/run/docker.sock
+                              name: docker-socket-path
+                    volumes:
+                        - name: docker-socket-path
+                          hostPath:
+                              path: /var/run/docker.sock
+              """
             )
             {
-                node('ccp-pipeline-master') {
+                node(POD_LABEL) {
                     def image_name = "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
 
                     //For the library images like centos and languages we push the image without an app_id

--- a/weekly-scan/scheduler.yaml
+++ b/weekly-scan/scheduler.yaml
@@ -32,7 +32,32 @@ objects:
         spec:
           template:
             metadata:
+                name: ccp-pipeline-weekly-trigger
+                labels:
+                    ccp-pipeline-build-pod-type: weekly-trigger
             spec:
+              serviceAccount: jenkins
+              namespace: pipeline
+              affinity:
+                  nodeAffinity:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                          nodeSelectorTerms:
+                              - matchExpressions:
+                                  - key: node-role.kubernetes.io/size
+                                    operator: In
+                                    values:
+                                        - large
+                  podAntiAffinity:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                          - topologyKey: kubernetes.io/hostname
+                            namespace: pipeline
+                            labelSelector:
+                                matchExpressions:
+                                      - key: ccp-pipeline-build-pod-type
+                                        operator: In
+                                        values:
+                                            - seed
+                                            - weekly-trigger
               containers:
                 - name: weekly-scan-scheduler
                   image: ${CCP_OPENSHIFT_SLAVE_IMAGE}

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -70,7 +70,7 @@ objects:
                     def image_name = (env.APP_ID == "library")? "${JOB_ID}:${DESIRED_TAG}": "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def image_tags = (env.APP_ID == "library")? "http://${REGISTRY_URL}/v2/${JOB_ID}/tags/list": "http://${REGISTRY_URL}/v2/${APP_ID}/${JOB_ID}/tags/list"
-                    def slave_container_name = POD_LABEL
+                    def slave_container_name = "${APP_ID}-${JOB_ID}-${DESIRED_TAG}-${BUILD_NUMBER}"
                     def slave_container_id = ""
                     def image_in_registry = false
                     // setting this to ensure the user is notified correctly if the required stages in weekly scan are complete
@@ -86,7 +86,7 @@ objects:
                         stage('Pull the container image'){
                             sh "docker pull ${image_name_with_registry}"
                             image_is_pulled = true
-                            slave_container_name = sh(returnStdout:true, script:  "echo ${POD_LABEL} | sed 's/_/-/g'").trim()
+                            slave_container_name = sh(returnStdout:true, script:  "echo ${slave_container_name} | sed 's/_/-/g'").trim()
                             echo "slave container name: ${slave_container_name}"
                             slave_container_id = sh(returnStdout:true, script: "docker ps -qf name=${slave_container_name} | head -n 1").trim()
                             echo "Slave container id: ${slave_container_id}"

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -19,33 +19,59 @@ objects:
             ])
             podTemplate(
                 cloud: 'openshift',
-                name: 'ccp-pipeline-weekly',
-                label: 'ccp-pipeline-weekly',
-                serviceAccount: 'jenkins',
-                containers: [
-                  containerTemplate(
-                    name: 'jnlp',
-                    image: '${CCP_OPENSHIFT_SLAVE_IMAGE}',
-                    ttyEnabled: true,
-                    alwaysPullImage: true,
-                    workingDir: '/tmp',
-                    privileged: true,
-                    args: '${computer.jnlpmac} ${computer.name}'
-                  )
-                ],
-                volumes: [
-                  hostPathVolume(
-                    hostPath: '/var/run/docker.sock',
-                    mountPath: '/var/run/docker.sock'
-                  )
-                ]
+                yaml: """
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                    name: ccp-weekly-scan
+                    labels:
+                        ccp-pipeline-build-pod-type: weekly-scan
+                spec:
+                    serviceAccount: jenkins
+                    namespace: pipeline
+                    affinity:
+                        nodeAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                                nodeSelectorTerms:
+                                    - matchExpressions:
+                                        - key: node-role.kubernetes.io/size
+                                          operator: In
+                                          values:
+                                              - small
+                        podAntiAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                                - topologyKey: kubernetes.io/hostname
+                                  namespace: pipeline
+                                  labelSelector:
+                                      matchExpressions:
+                                            - key: ccp-pipeline-build-pod-type
+                                              operator: In
+                                              values:
+                                                  - master
+                                                  - weekly-scan
+                    containers:
+                      - name: jnlp
+                        image:  ${CCP_OPENSHIFT_SLAVE_IMAGE}
+                        tty: true
+                        imagePullPolicy: Always
+                        workingDir: /tmp
+                        privileged: true
+                        volumeMounts:
+                            - mountPath: /var/run/docker.sock
+                              name: docker-socket-path
+                    volumes:
+                        - name: docker-socket-path
+                          hostPath:
+                              path: /var/run/docker.sock
+              """
             )
             {
-                node('ccp-pipeline-weekly') {
+                node(POD_LABEL) {
                     def image_name = (env.APP_ID == "library")? "${JOB_ID}:${DESIRED_TAG}": "${APP_ID}/${JOB_ID}:${DESIRED_TAG}"
                     def image_name_with_registry = "${REGISTRY_URL}/${image_name}"
                     def image_tags = (env.APP_ID == "library")? "http://${REGISTRY_URL}/v2/${JOB_ID}/tags/list": "http://${REGISTRY_URL}/v2/${APP_ID}/${JOB_ID}/tags/list"
-                    def slave_container_name = "jnlp_ccp-pipeline-weekly"
+                    def slave_container_name = POD_LABEL
+                    def slave_container_id = ""
                     def image_in_registry = false
                     // setting this to ensure the user is notified correctly if the required stages in weekly scan are complete
                     def success = false
@@ -60,24 +86,28 @@ objects:
                         stage('Pull the container image'){
                             sh "docker pull ${image_name_with_registry}"
                             image_is_pulled = true
+                            slave_container_name = sh(returnStdout:true, script:  "echo ${POD_LABEL} | sed 's/_/-/g'").trim()
+                            echo "slave container name: ${slave_container_name}"
+                            slave_container_id = sh(returnStdout:true, script: "docker ps -qf name=${slave_container_name} | head -n 1").trim()
+                            echo "Slave container id: ${slave_container_id}"
                         }
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/yumupdates.py > yum-check-update 2>&1")
+                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/yumupdates.py > yum-check-update 2>&1")
                                   sh "cat yum-check-update"
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/rpmverify.py > rpm-verify 2>&1")
+                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/rpmverify.py > rpm-verify 2>&1")
                                   sh "cat rpm-verify"
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/misc_package_updates.py all > misc-updates 2>&1")
                                   sh "cat misc-updates"
                                 },
                                 "Container capabilities": {
                                   def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from `docker ps -qf name=${slave_container_name} | head -n 1` --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                  sh (returnStdout: true, script: "docker run --rm --user root --volumes-from ${slave_container_id} --entrypoint /usr/bin/python ${image_name} /opt/ccp-openshift/ccp/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
                                   sh "cat capabilities"
                                 }
                             )


### PR DESCRIPTION
This PR
* Assigns api-server, seed-job and weeekly scan trigger jobs to large nodes
* Assigns the weekly-scan and master-build jobs to small nodes
* makes sure the build jobs runs only one per node (avoids parallel processing for single docker socket)
* Updates CI to run based on pod and node affinity 