### PR TITLE
Updated centos version for api server

### DIFF
--- a/Dockerfiles/ccp-api-server/Dockerfile
+++ b/Dockerfiles/ccp-api-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos/centos:latest
+FROM registry.centos.org/centos/centos:7
 
 RUN yum -y update && \
     yum install -y epel-release && \


### PR DESCRIPTION
This is to make sure the api server image is centos 7 while the latest is pointed to centos8